### PR TITLE
Changed 'f' in français to capital 'F'

### DIFF
--- a/locale/dialect-list.yml
+++ b/locale/dialect-list.yml
@@ -48,7 +48,7 @@ defaults: &defaults
   fi: Suomi
   fj: Na Vosa Vakaviti
   fo: Føroyskt
-  fr: français
+  fr: Français
   fy: Frysk
   ga: Gaeilge
   gl: Galego


### PR DESCRIPTION
Other languages (written with Roman alphabet) seemed to use a capital first letter, so changed this 'f' for consistency