### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: madiedgar
+github: legesher


### PR DESCRIPTION
## Summary
- Add FUNDING.yml to enable the "Sponsor" button on the repository
- Links to the Legesher GitHub Sponsors page

## Test plan
- [ ] Verify the Sponsor button appears on the repository page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)