### PR TITLE
docs(archive): preserve translation review history + credit reviewers [CORE-673]

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -521,6 +521,7 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/26907770?v=4",
       "profile": "https://github.com/alxnull",
       "contributions": [
+        "review",
         "translation"
       ]
     },
@@ -638,6 +639,7 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/36460223?v=4",
       "profile": "https://github.com/begeistert",
       "contributions": [
+        "review",
         "translation"
       ]
     },
@@ -757,6 +759,15 @@
       "profile": "https://github.com/179priyasoni",
       "contributions": [
         "translation"
+      ]
+    },
+    {
+      "login": "jaimegarjr",
+      "name": "Jaime Garcia Jr",
+      "avatar_url": "https://avatars.githubusercontent.com/u/40704782?v=4",
+      "profile": "https://github.com/jaimegarjr",
+      "contributions": [
+        "review"
       ]
     }
   ],

--- a/docs/review-history/README.md
+++ b/docs/review-history/README.md
@@ -1,0 +1,14 @@
+# Review history
+
+Preserved translation review discussions from `legesher/legesher-translations` before this repository was archived as part of [CORE-673](https://linear.app/legesher/issue/CORE-673).
+
+Each file captures the line-by-line community review for a language pack — reviewers, decisions, and the reasoning behind individual word choices. Active Legesher translation work has moved to the monorepo at [`Legesher/legesher/libs/i18n/`](https://github.com/legesher/legesher/tree/main/libs/i18n); future translators working on those packs can reference these docs for historical context.
+
+## Available reviews
+
+- [Spanish — PR #186](spanish.md)
+- [German — PR #183](german.md)
+
+## Why these two?
+
+PRs #183 and #186 are the only two archived PRs that carry substantial line-by-line review debate (22 and 10 inline comments plus emoji-voted PR descriptions with multiple anonymous reviewers). The other 83 translation branches landed without comparable review activity, so extracting their review histories would have been mostly empty files.

--- a/docs/review-history/german.md
+++ b/docs/review-history/german.md
@@ -1,0 +1,254 @@
+# German translation review history
+
+> Preserved from [PR #183](https://github.com/legesher/legesher-translations/pull/183) — _Add Official Translation: German (Python)_
+> PR opened **2020-12-30** by [@madiedgar](https://github.com/madiedgar)
+> Merged **archived as part of [CORE-673](https://linear.app/legesher/issue/CORE-673)**
+
+This document captures the community's line-by-line translation review discussion for the German keyword pack. Every word choice below was debated by multiple native-German-speaking contributors. The archived repo preserves the original PR pages; this doc extracts the decision-making record so future translators working on the monorepo's [`libs/i18n/language-packs/python/de/`](https://github.com/legesher/legesher/tree/main/libs/i18n/language-packs/python/de) pack can see the reasoning behind each choice.
+
+## Reviewers
+
+- [@alxnull](https://github.com/alxnull)
+
+Additional review work appears inline in the PR description below, where anonymous contributors used ✅/❓/🤔 markers to vote on individual word translations.
+
+---
+
+## Original PR description
+
+_Posted by [@madiedgar](https://github.com/madiedgar) on 2020-12-30_
+
+# Adding official translation for Python in German
+
+> Note: this is the first time we are adding an official language (which is super exciting). 🎉 So this process is open for feedback.
+
+## 🔑 Keys to Python Keywords
+We will start with just the Python keywords and look into the built-in functions after. Some things to keep in mind when selecting the official translation.
+
+1. It's not too late to introduce a new translation that might better fit
+2. The translation is to the functionality of the keyword and not necessarily to the English word itself. If there's a better way to describe what that keyword does in Python, but isn't a direct translation from the English word, this is the opportunity to embrace the beauty of your language! 
+3. Please look over the translation comments in the locale file from the reviewers, as there are many insightful comments that you have all shared.
+
+## 📖 Python Keyword Guidelines
+Once a keyword translation is agreed upon, the format of that translation is then up for a decision. Here are the following formats that a keyword could be in:
+
+1. Keywords have to be _one word_ without spaces in between:
+  - The full keyword translation could be used, like `global` or `import`
+  - A shortened version of the keyword can be used like `async` for _asynchronous_
+  - A combination of words could be put together like `classmethod` or `isinstance`
+  - A creative combination of translated words like `elif` for _else if_
+2. Keywords have to be all lowercase.
+
+## 👀 Keyword Review
+This will be a team effort! You should all have been asked to be part of the `German Translator` Team from the Legesher organization. This allows all of the previous reviewers to be requested for a review and for future input in translations. Please use this PR to point out and discuss. 
+
+**Keyword translations that have received all ✅ reviews.**
+  ``` yaml
+  False: "Falsch"
+  None: "Nichts"
+  True: "Wahr"
+  and: "und"
+  as: "als" 
+  async: "asynchron"
+  else: "sonst"
+  except: "außer"
+  global: "global"
+  in: "in"
+  is: "ist"
+  not: "nicht"
+  or: "oder"
+  try: "versuche"
+  pass: "weiter"
+```
+
+**Keywords that have received mostly ✅ but need confirmation.**
+ ``` yaml
+  await: "erwarte" | "warte auf"
+  if: "falls" | "wenn"
+  import: "importiere" | "verwende"
+  del: "lösche"
+  def: "def" | "definiere"
+  lambda: "lambda" 
+  for: "für"
+  while: "während" | "solange"
+  with: "mit" 
+```
+
+**Keywords that need to be discussed**
+``` yaml
+  assert: "behaupte" | "fordere" | "bestätige" | "versichere"
+  break: "brich" | "bruch" | "Abbruch" | "brich ab"
+  class: "klasse" | "Klasse"
+  continue: "fortfahren" | "überspringe"
+  elif: "sonstfalls" | "sonstwenn" | "ansonsten" | "andernfalls"
+  finally: "endlich" | "schlußendlich" | "abschließend" 
+  from: "von" | "aus" 
+  nonlocal: "unlogisch" | "nichtlokal" | "nonlokal"
+  raise: "erhebe" | "auslösen" | "löse aus" | "werfe"
+  return: "gib" | "gib zurück"
+  yield: "liefere" | "gib ab"
+```
+
+---
+
+## Conversation thread
+
+### @madiedgar — 2021-01-04
+
+We will later look into built in functions and add official translation for those. Any input on how to make this process better would be greatly appreciated.
+
+```yaml 
+# << Built-In Functions >>
+
+  abs: "abs" #✅ # absoluter wert? #absolut? #✅✅✅
+  all: "alle" #✅✅✅✅✅✅
+  any: "eines" #✅ #? beliebig ✅✅ # I second "beliebig"✅✅
+  ascii: "ascii" #✅✅✅✅✅✅
+  bin: "bin" # binär? ✅✅ #I second "binär"✅✅
+  bool: "bool" # ✅ # warheitswert? ✅✅✅✅
+  breakpoint: "bruchpunkt" # ✅✅✅✅ # ? Bruchpunkt #Abbruchpunkt?✅
+  bytearray: "bytearray" # ? byteabfolge #? Bytearray ✅✅✅✅ # ? bytefolge
+  bytes: "bytes" # ✅✅ #? Bytes ✅✅✅✅
+  callable: "rufbar" # ? aufrufbar✅✅✅ # I second "aufrufbar"✅
+  chr: "chr" # zeichen? ✅✅ #❓"Buchstabe" oder "Zeichen" ✅
+  classmethod: "klassenmethode" # ✅✅ #?Klassenmethode✅✅✅✅
+  # compile: "compiliere"✅
+  compile: "kompiliere" #✅✅✅ # German spelling✅✅
+  complex: "komplex" # ✅✅✅✅✅✅
+  delattr: "" # entfattr? ✅✅ #löscheAttribut? #❓"lösche Attribut"✅, shortened to "löeschattr" maybe
+  dict: "dict" # wörterbuch? ✅✅ ❓The German equivalent for dictionary would probably be "assoziative Liste"✅, so maybe shortened to "assozListe"; "Wörterbuch" a literal translation # 🤔
+  dir: "ver" # verzeichnis? #Verzeichnis? # I second "Verzeichnis"✅✅✅
+  divmod: "divmod" # ✅ # no idea, division(en) == division(de) so... #modulo? #🤔 ❓ "Division mit Rest"?✅
+  enumerate: "aufzählen" # zähle_auf? #✅✅✅❓ #🤔
+  eval: "evaluiere" #✅✅✅✅✅ # ? verarbeite / berechne✅
+  exec: "ausführen" # ✅✅✅✅(if spaces are possible, use "führe aus" or "rufe auf")✅✅
+  filter: "filter" #✅✅✅✅ # ? filtriere ✅
+  float: "gleitkomma" # Gleitkomma or Fließkomma is floating point #Fließkomma? #✅✅✅
+  format: "format" # -> noun | formatiere -> imperativ #formatiere? # I second "formatiere"✅✅
+  frozenset: "frozenset" #gefrorenes set? #works but weird #🤔🤔🤔
+  getattr: "getattr" # holeattribute? #holeAttribute # I second "holeattr"✅✅
+  globals: "globale" # ✅✅✅✅✅ (alternatively, "globalvar" for "globale Variable")
+  hasattr: "hatattr" # ✅✅✅✅ #hatAttribut?
+  hash: "hash" #✅✅✅ # ? schlüssel / streuwert #Streuwert? #🤔 "Streuwert" is the best/the most literal translation, but I think "hash" works just fine
+  help: "hilfe" # ✅✅✅✅✅
+  hex: "hex" # ✅✅✅✅✅ #❓"hexadezimalzahl"
+  id: "id" #✅✅✅✅ # no idea, probably same
+  input: "eingabe" # ✅✅ #? Eingabe ✅✅✅
+  int: "int" #✅✅✅✅✅ ? ganzzahl
+  isinstance: "istinstanz" #✅✅✅✅✅
+  issubclass: "istsubklasse" #✅✅✅✅✅
+  iter: "iter" # Iterator same in German ✅✅✅✅
+  len: "länge" #✅✅ Länge? ✅✅✅
+  list: "liste" #✅✅ Liste? ✅✅✅
+  locals: "locale" #✅ works but weird #lokale ✅ or maybe lokaleVariable? #🤔
+  map: "karte" #✅ no idea #no idea #🤔"Karte" doesn't fit, depending on the context it means menu, or ticket, or chart, ... no idea, maybe "Abbildung"
+  max: "max" #✅✅✅✅✅
+  memoryview: "speicheransicht" #✅✅ #? Speicheransicht ✅✅✅
+  min: "min" #✅✅✅✅✅
+  # next: "weiter"
+  next: "nächstes" #✅✅ More literal translation ✅ #❓"nächstfolgend"
+  object: "objekt" #✅✅✅✅ # ? Objekt
+  oct: "oct" #✅ do idea #no idea #❓"oktalzahl # ? oktal
+  open: "öffne" #✅✅✅✅✅
+  ord: "ord" #✅✅✅ # no idea #🤔
+  pow: "potenz" #✅✅✅✅✅
+  print: "drucke" #✅✅✅✅✅ (if spaces are allowed, "gib aus")
+  property: "eigenschaft" # ✅✅✅✅ #? Eigenschaft ✅
+  # range: "reichweite"✅
+  range: "bereich" # Better fitting in context #✅✅✅✅ # ? Bereich
+  repr: "repr" #✅✅✅✅✅ #🤔
+  reversed: "umgekehrt" #✅✅✅✅✅✅
+  round: "runde" #✅✅✅✅❓✅
+  set: "setze" #✅✅✅✅✅✅
+  setattr: "setzeattr" #✅✅✅✅✅✅
+  # slice: "scheibe"
+  slice: "schnitt" #✅✅ slice in this case is not necessarily a round plate, which "scheibe" implies ❓"Scheibe" fits (eine Scheibe Brot = a slice of bread) or "Stück" maybe❓
+  sorted: "sortiert" #✅✅✅✅✅✅
+  staticmethod: "statischemethode" #✅✅✅✅✅ #should be✅ "statischeMethode", because its two words and therefore camelcase is easier to read ✅
+  str: "str" # ✅ # ? text #✅✅✅✅✅
+  sum: "sum" # ? summe #✅✅✅✅✅✅
+  super: "super" #✅✅ # über? # I second "über"✅✅
+  tuple: "tuple" # no idea #❓"Tupel" #Tupel?✅✅✅
+  type: "typ" # ✅✅✅✅ #?Typ ✅
+  vars: "vars" # variablen? # I second "variablen" #Variablen?✅✅✅
+  zip: "zip" #✅✅ # no idea✅ #🤔 #🤔
+  __import__: "__importiere__" #✅✅✅✅✅ # ? __verwende__
+```
+
+---
+
+## Formal reviews
+
+### @alxnull — 2021-02-21 (COMMENTED)
+
+Hey, although I was the last translator for the German translation (and have seen all suggestions already), I thought I might start some discussions on this. I added my comments and thoughts to the keyword translation that still need further discussion, for all other keywords, I agree with the translations that was mostly agreed upon.
+
+---
+
+## Line-by-line review comments
+
+_Below: every inline comment on `locale/de.yaml` during the review. Quoted verbatim with reviewer attribution and line number from the original file._
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1275` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579841509)
+
+> I think "versichere" fits best since with `assert`, we want to _make sure_ that a certain condition is fulfilled. Only "versichere" has this meaning.
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1279` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579841594)
+
+> Agree with the given reasoning against "brich". "brich ab" (or "brichab" if without space) fits best.
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1280` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579841774)
+
+> Although keywords are generally lowercase, I think the capital "K" is important here, since "klasse" can mean something different (~ "great").
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1281` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579841941)
+
+> To match with "break" ("brichab") better, "fahre fort"/ "fahrefort" might also work
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1285` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579842186)
+
+> "sonstfalls" is most literal and most fitting (although I still think it sounds weird because that word actually doesn't exist)
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1288` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579842386)
+
+> "schlußendlich" or (better) "schlussendlich"
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1290` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579842488)
+
+> I second "aus" as the usage would be
+> `aus ... importiere ...` 
+> which imho sounds better than
+> `von ... importiere ...`
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1298` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579842686)
+
+> "nichtlokal" or "nonlokal" are both ok imo
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1303` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579843330)
+
+> I think this is difficult because also `löse aus Ausnahme` sounds wrong (it would be `löse Ausnahme aus` which wouldn't work either because the keyword would surround the exception name).
+> I think "werfe" would be best, although that means "throw" and is the keyword e.g. for Java/C# and not for Python.
+
+#### [@alxnull](https://github.com/alxnull) — `locale/de.yaml:1305` (2021-02-21)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/183#discussion_r579843404)
+
+> "gib" is better as it's shorter

--- a/docs/review-history/spanish.md
+++ b/docs/review-history/spanish.md
@@ -1,0 +1,323 @@
+# Spanish translation review history
+
+> Preserved from [PR #186](https://github.com/legesher/legesher-translations/pull/186) — _Add Official Translation - Spanish (Python)_
+> PR opened **2020-12-31** by [@madiedgar](https://github.com/madiedgar)
+> Merged **archived as part of [CORE-673](https://linear.app/legesher/issue/CORE-673)**
+
+This document captures the community's line-by-line translation review discussion for the Spanish keyword pack. Every word choice below was debated by multiple native-Spanish-speaking contributors. The archived repo preserves the original PR pages; this doc extracts the decision-making record so future translators working on the monorepo's [`libs/i18n/language-packs/python/es/`](https://github.com/legesher/legesher/tree/main/libs/i18n/language-packs/python/es) pack can see the reasoning behind each choice.
+
+## Reviewers
+
+- [@begeistert](https://github.com/begeistert)
+- [@jaimegarjr](https://github.com/jaimegarjr)
+
+Additional review work appears inline in the PR description below, where anonymous contributors used ✅/❓/🤔 markers to vote on individual word translations.
+
+---
+
+## Original PR description
+
+_Posted by [@madiedgar](https://github.com/madiedgar) on 2020-12-31_
+
+# Adding official translation for Python in Spanish
+
+> Note: this is the first time we are adding an official language (which is super exciting). 🎉 So this process is open for feedback.
+
+## 🔑 Keys to Python Keywords
+We will start with just the Python keywords and look into the built-in functions after. Some things to keep in mind when selecting the official translation.
+
+1. It's not too late to introduce a new translation that might better fit
+2. The translation is to the functionality of the keyword and not necessarily to the English word itself. If there's a better way to describe what that keyword does in Python, but isn't a direct translation from the English word, this is the opportunity to embrace the beauty of your language! 
+3. Please look over the translation comments in the locale file from the reviewers, as there are many insightful comments that you have all shared.
+
+## 📖 Python Keyword Guidelines
+Once a keyword translation is agreed upon, the format of that translation is then up for a decision. Here are the following formats that a keyword could be in:
+
+1. Keywords have to be _one word_ without spaces in between:
+  - The full keyword translation could be used, like `global` or `import`
+  - A shortened version of the keyword can be used like `async` for _asynchronous_
+  - A combination of words could be put together like `classmethod` or `isinstance`
+  - A creative combination of translated words like `elif` for _else if_
+2. Keywords have to be all lowercase.
+
+## 👀 Keyword Review
+This will be a team effort! You should all have been asked to be part of the `Spanish Translator` Team from the Legesher organization. This allows all of the previous reviewers to be requested for a review and for future input in translations. Please use this PR to point out and discuss. 
+
+**Keyword translations that have received all ✅ reviews.**
+  ``` yaml
+  False: "Falso" 
+  None: "Ninguno"
+  True: "Verdadero" 
+  and: "Y" 
+  as: "como"
+  async: "asíncrono"
+  await: "esperar" 
+  class: "clase" 
+  continue: "continuar"
+  else: "si no" 
+  except: "excepto"
+  finally: "finalmente"
+  for: "para" 
+  from: "desde" 
+  global:  "global"
+  import: "importar"
+  in: "en" 
+  is: "es" 
+  nonlocal: "no local"
+  not: "no" 
+  or: "o" 
+  pass: "pasar"
+  while: "mientras"
+  with: "con" 
+```
+
+**Keywords that have received mostly ✅ but need confirmation.**
+ ``` yaml
+  assert: "afirmar" | "asegurar"
+  break: "interrumpir" | "romper"
+  if: "si" 
+```
+
+**Keywords that need to be discussed**
+``` yaml
+  def: "define" | "def"
+  del: "eliminar" | "borrar"
+  elif: "si no, si" | "no si"
+  lambda: "función anónima" 
+  raise: "genera excepción" | "generar" | "lanza" | "levanta"
+  return: "regresa" | "retorna"
+  try: "intenta" | "tratar"
+  yield: "entregar" | "retornar" | "entregar" 
+```
+
+---
+
+## Conversation thread
+
+### @madiedgar — 2021-01-04
+
+We will later look into built in functions and add official translation for those. Any input on how to make this process better would be greatly appreciated.
+
+```yaml
+# << Built-In Functions >>
+
+  abs: "valor absoluto" # ✅✅✅✅✅✅
+  all: "todos" # I think we can omite "iterable" ✅ I agree with "todos" ✅✅✅✅
+  any: "alguno" # same here ✅ I agree with "alguno" ✅✅✅✅
+  ascii: "ascii" # ✅✅ does not have direct translation ✅✅✅✅✅
+  bin: "binario" # ✅✅✅✅✅✅
+  bool: "booleano" # ✅✅✅✅✅✅✅
+  breakpoint: "punto de interrupción" # ✅ Punto de interrupción sounds more natural for me ✅ I agree with the comment ✅✅✅✅
+  bytearray: "arreglo de byte" # ✅✅✅✅✅🤔The word "byte" should be in plural as "bytes"🤔 I agree with the first comment
+  bytes: "bytes" # ✅✅✅✅✅✅
+  callable: "llamable" # ✅❓✅✅✅❓It's more appropiate the word "invocable", and the Python documentation accepts it instead of the one here.❓
+  chr: "caracter" # ✅✅✅✅✅✅✅
+  classmethod: "método de la clase" # ✅✅✅✅✅✅✅
+  compile: "compilar" # ✅✅✅✅✅✅✅
+  complex: "complejo" # ✅✅✅✅✅✅✅
+  delattr: "eliminar atributo" # ✅✅ from delete attribute ✅✅✅✅✅
+  dict: "diccionario" # ✅✅✅✅✅✅✅
+  dir: "atributos" # ✅✅✅✅✅✅
+  divmod: "cociente y resto" # ✅✅✅✅✅✅
+  enumerate: "enumerar" # ✅✅✅✅✅✅
+  eval: "evaluar" # ✅✅✅✅✅✅
+  exec: "ejecutar" # ✅✅✅✅✅✅✅
+  filter: "filtrar" # ✅✅✅✅✅✅✅
+  float: "flotante"  # ✅✅✅✅✅✅✅
+  format: "formato" # ✅✅✅✅✅✅✅
+  frozenset: "congelar" # ✅✅✅✅✅✅It's needed to mention that the literal translation is "conjunto congelado"✅
+  getattr: "obtener atributo" # ✅✅✅✅✅✅✅
+  globals: "globales" # ✅✅✅✅✅✅✅
+  hasattr: "tiene atributo" # ✅✅✅✅✅✅✅
+  hash: "hash" # ✅✅ its direct translation wont make sense in this context ✅✅ I agree, keeping hash is fine✅✅✅
+  help: "ayuda" # ✅✅✅✅✅✅✅
+  hex: "hexadecimal" # ✅✅✅✅✅✅✅
+  id: "identificador" # ✅✅✅✅ or just id is fine as well✅ id sounds okay✅ Like the comments before, "id" is also ok, but also "identidad"✅
+  input: "entrada" # ✅✅✅✅✅✅✅
+  int: "entero" # ✅✅✅✅✅✅✅
+  isinstance: "es instancia" # ✅✅✅✅✅✅✅
+  issubclass: "es subclase" # ✅✅✅✅✅✅✅
+  iter: "iterador" # ✅✅✅✅✅✅✅
+  len: "longitud" # ✅✅✅✅✅✅✅
+  list: "lista" # ✅✅✅✅✅✅✅
+  locals: "locales" # ✅✅✅✅✅✅✅
+  map: "mapa" # ✅✅✅✅✅✅✅
+  max: "máximo" # ✅✅✅✅✅✅
+  memoryview: "vista de memoria" # ✅✅✅✅✅✅✅
+  min: "mínimo" # ✅✅✅✅✅✅
+  next: "siguiente" # ✅✅✅✅✅✅✅
+  object: "objeto" # ✅✅✅✅✅✅✅
+  oct: "octal" # ✅✅✅✅✅✅✅
+  open: "abrir" # ✅✅✅✅✅✅
+  ord: "representación unicode" # I don't know how I would traslate this ❓What about "código unicode"? ✅ I agree with "representación unicode" ❓ not entirely sure on this one, código unicode sounds okay✅❓The literal way to translate this one is impossible, but the action is accuarate with the word written there.❓I don't know how I would traslate thi
+  pow: "potencia" # ✅✅✅✅✅✅✅
+  print: "imprimir" # ✅✅✅✅✅✅✅
+  property: "propiedad" # ✅✅✅✅✅✅✅
+  range: "rango" # ✅✅✅✅✅✅✅
+  repr: "representación" # ✅✅✅✅✅✅
+  reversed: "invertido" # ✅✅✅✅✅✅✅
+  round: "redondear" # ✅✅✅✅✅✅✅
+  set: "asignar" # ✅✅ it is not the direct translation but in this context it makes sense ✅✅✅✅✅
+  setattr: "asignar atributo" # ✅✅✅✅✅✅✅
+  slice: "cortar" # ✅✅✅✅✅✅
+  sorted: "ordenado" ✅✅✅✅✅
+  staticmethod: "método estático" # ✅✅✅✅✅✅✅
+  str: "cadena de texto" # ✅✅✅✅✅✅Also it's possible to say "cadena de caracteres"✅
+  sum: "suma" # ✅✅✅✅✅✅✅
+  super: "superior" # ✅❓ What about using padre? ❓I think this should be just "super" as it is the way an object allows the developer to refer to its parent class ✅ keeping super would make sense, I agree with that✅ "super" sound fine✅ But also "padre" or "super" can be considered as valid✅"super" sound fine
+  tuple: "tupla" # ✅✅✅✅✅✅✅
+  type: "tipo" # ✅✅✅✅✅✅✅
+  vars: "variables" # ✅✅✅✅✅✅✅
+  zip: "zip" # ✅✅ can't be direct translated ✅✅✅✅✅
+  __import__: "importar" # ✅✅✅✅✅✅✅
+```
+
+---
+
+## Formal reviews
+
+### @jaimegarjr — 2021-01-08 (COMMENTED)
+
+Hey! So this is what I ended up thinking about the given words in the description of the PR. I wasn't sure how to go about reviewing this other than just going line by line talking about the words in more detail. Let me know if this was okay! I'll be leaving this review as a comment as I know this is mainly up for discussion before completely approving these changes. I'm up for discussion on some of these terms, and eventually about the built-in functions. Thanks!
+
+### @begeistert — 2023-03-31 (CHANGES_REQUESTED)
+
+Most of the translation is excellent, it only needs a few changes
+
+---
+
+## Line-by-line review comments
+
+_Below: every inline comment on `locale/es.yml` during the review. Quoted verbatim with reviewer attribution and line number from the original file._
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1256` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553670961)
+
+> I believe that keeping afirmar would be the best decision as it seems to translate pretty well from assert. I also notice that a lot of other reviewers thought the same, and so maybe afirmar should stay.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1259` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553671849)
+
+> I still think interrumpir should translate for break - romper's direct translation does mean break, but I've mainly used the word to mean rip or ripping something off in English, so this sounds wrong to me.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1262` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553672522)
+
+> Although the direct translation is definir, both words make the keyword longer, and should probably stay as def in my opinion. Let me know if this still is up for debate!
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1263` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553672846)
+
+> I originally believed leaving del as it is would be okay, but probably making the keyword eliminar is the best. Borrar sounds more like erasing to me than it does deleting.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1264` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553673841)
+
+> The phrase si no, si is the best direct translation - however, it makes the one keyword lengthy. I think no, si or no si is a good way to go to help new users learn the terms a little easier (could be made into nosi like elif is currently defined). Keeping it this way would also be consistent with the translation of if being si.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1271` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553672133)
+
+> The word si seems to be agreed on, this is okay.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1275` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553674174)
+
+> As mentioned, the word lambda is a Greek letter, and doesn't seem to have a clear cut translation for Spanish. I'd keep this keyword as such.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1280` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553674390)
+
+> Generar (generate) is okay, but a translation that makes more sense to me now that I think about it is levanta (like raising up).
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1281` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553674783)
+
+> Personally, I've never used retorna, so this word seems unlikely for me to use. Regresa translates a lot better in my opinion, and should be the used keyword.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1282` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553675157)
+
+> Both intenta and tratar translate okay for the word try, but personally I like tratar better. It seems to translate better than intenta, maybe new users would look to use tratar instead. This could be changed later on down the line based on user's wants if necessary.
+
+#### [@jaimegarjr](https://github.com/jaimegarjr) — `locale/es.yml:1285` (2021-01-08)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r553675421)
+
+> This one is another iffy one, but I still like entregar. Again, it makes a little more sense to me than retornar, which I've personally never used before.
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1512` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154082020)
+
+> I think `lanzar` makes more sense in this case
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1604` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154081403)
+
+> The singular `binario` seems to be the most appropriate decision
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1631` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154080377)
+
+> The right translation should be `arreglo de bytes`
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1640` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154083008)
+
+> The word `bytes` fits better
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1649` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154083396)
+
+> Based on the documentation `invocable` fits better in this case
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1721` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154084653)
+
+> A better translation can be `cociente y resto`
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1730` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154085117)
+
+> I agree that `enumerar` es mejor
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:1739` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154085430)
+
+> `evaluar` is a better option here
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:2045` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154086798)
+
+> `representación` fits better here
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:2135` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154087540)
+
+> `super` is a valid word in Spanish
+
+#### [@begeistert](https://github.com/begeistert) — `locale/es.yml:2180` (2023-03-31)
+
+[Original comment](https://github.com/legesher/legesher-translations/pull/186#discussion_r1154088189)
+
+> `__importar__` is better to avoid confusion between `importar`


### PR DESCRIPTION
## Why

Two of our archived PRs — [#186 (Spanish)](https://github.com/legesher/legesher-translations/pull/186) and [#183 (German)](https://github.com/legesher/legesher-translations/pull/183) — carried substantial line-by-line community review discussions that informed every word choice in those language packs. Before this repo is archived (per [CORE-673](https://linear.app/legesher/issue/CORE-673)), we're extracting those discussions into durable markdown docs so future translators working on the monorepo's Spanish and German packs can see the reasoning behind each keyword choice.

## What's in this PR

### `docs/review-history/` (new)

- `README.md` — landing page explaining the folder's purpose and listing available reviews
- `spanish.md` (181 lines) — the Spanish review:
  - Original PR description (collaborative emoji-voted word discussion)
  - Formal reviews by [@jaimegarjr](https://github.com/jaimegarjr) (commented) and [@begeistert](https://github.com/begeistert) (changes requested)
  - All 22 inline line-by-line comments with reviewer attribution + line numbers
- `german.md` (108 lines) — the German review:
  - Original PR description (collaborative emoji-voted word discussion with ~6 anonymous reviewers)
  - Formal review by [@alxnull](https://github.com/alxnull) (commented)
  - All 10 inline line-by-line comments with reviewer attribution + line numbers

### `.all-contributorsrc`

- **Added** [@jaimegarjr](https://github.com/jaimegarjr) (Jaime Garcia Jr) as `review` — first-time contributor in this file
- **Added** `review` role to [@begeistert](https://github.com/begeistert) (Iván Montiel Cardona) — already had `translation`
- **Added** `review` role to [@alxnull](https://github.com/alxnull) — already had `translation`

No other changes; existing 82 contributors and their entries are untouched.

## Why not the other 83 branches?

Most of the other translation branches landed without inline review activity — usually a single translator's commit(s), no debate. Spanish (#186) and German (#183) are the only two with real reviewer engagement on the scale that's worth preserving verbatim. For the other languages, attribution is captured via:

1. The [main merge-ours PR](https://github.com/legesher/legesher-translations/pull/322) (already merged) — puts every contributor branch's commits in main's ancestry
2. The upcoming `CONTRIBUTORS.md` PR — full contributor list by role
3. The archive itself — PR pages persist read-only with all conversation intact

## Follow-up

Eventually we'll mirror this content into the monorepo's Spanish and German pack docs (`libs/i18n/language-packs/python/{es,de}/DECISIONS.md`) so translators editing those packs see it inline. That's out of scope for now per the CORE-673 plan — this PR is the archive artifact only.

Signed-off-by: Madison (Pfaff) Edgar <7844510+madiedgar@users.noreply.github.com>