### PR TITLE
feat(translations): integrate sarr266 Urdu review + Collins Swahili/Ruby keywords [CORE-673]

### DIFF
--- a/locale/sw.yml
+++ b/locale/sw.yml
@@ -1,0 +1,1917 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "sw"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "uwongo"
+    # ✅ @wambugucoder
+  None: "hakuna"
+    # ✅ @wambugucoder
+  True: "ukweli"
+    # ✅ @wambugucoder
+  and: "na"
+    # ✅ @wambugucoder
+  as: "kama"
+    # ✅ @wambugucoder
+  assert: "sisitiza"
+    # ✅ @wambugucoder
+  async: "async"
+    # ✅ @wambugucoder
+  await: "ngoja"
+    # ✅ @wambugucoder
+  break: "vunja"
+    # ✅ @wambugucoder
+  class: "darasa"
+    # ✅ @wambugucoder
+  continue: "endelea"
+    # ✅ @wambugucoder
+  def: "fafanua"
+    # ✅ @wambugucoder
+  del: "duta"
+    # ✅ @wambugucoder
+  elif: "vinginevyo"
+    # ✅ @wambugucoder
+  else: "ikiwa-si-ivyo"
+    # ✅ @wambugucoder
+  except: "isipokuwa"
+    # ✅ @wambugucoder
+  finally: "mwishowe"
+    # ✅ @wambugucoder
+  for: "kwa"
+    # ✅ @wambugucoder
+  from: "kutoka"
+    # ✅ @wambugucoder
+  global: "kimataifa"
+    # ✅ @wambugucoder
+  if: "kama"
+    # ✅ @wambugucoder
+  import: "agiza"
+    # ✅ @wambugucoder
+  in: "ndani"
+    # ✅ @wambugucoder
+  is: "ni"
+    # ✅ @wambugucoder
+  lambda: "lambda"
+    # ✅ @wambugucoder
+  nonlocal: "isiyo-ya-kawaida"
+    # ✅ @wambugucoder
+  not: "si"
+    # ✅ @wambugucoder
+  or: "au"
+    # ✅ @wambugucoder
+  pass: "pita"
+    # ✅ @wambugucoder
+  raise: "inua"
+    # ✅ @wambugucoder
+  return: "rudisha"
+    # ✅ @wambugucoder
+  try: "jaribu"
+    # ✅ @wambugucoder
+  while: "wakati"
+    # ✅ @wambugucoder
+  with: "na"
+    # ✅ @wambugucoder
+  yield: "mavuno"
+    # ✅ @wambugucoder
+
+# << Built-In Functions >>
+
+  abs: "abs"
+    # ✅ @wambugucoder
+  all: "yote"
+    # ✅ @wambugucoder
+  any: "yoyote"
+    # ✅ @wambugucoder
+  ascii: "ascii"
+    # ✅ @wambugucoder
+  bin: "bin"
+    # ✅ @wambugucoder
+  bool: "bool"
+    # ✅ @wambugucoder
+  breakpoint: "mahali-pa-kuvunja"
+    # ✅ @wambugucoder
+  bytearray: "baiti-safu"
+    # ✅ @wambugucoder
+  bytes: "baiti"
+    # ✅ @wambugucoder
+  callable: "inayoitwa"
+    # ✅ @wambugucoder
+  chr: "tabia"
+    # ✅ @wambugucoder
+  classmethod: "njia-ya-darase"
+    # ✅ @wambugucoder
+  compile: "kusanya"
+    # ✅ @wambugucoder
+  complex: "tata"
+    # ✅ @wambugucoder
+  delattr: "futa-sifa"
+    # ✅ @wambugucoder
+  dict: "kamusi"
+    # ✅ @wambugucoder
+  dir: "saraka"
+    # ✅ @wambugucoder
+  divmod: "divmod"
+    # ✅ @wambugucoder
+  enumerate: "kuhesabu"
+    # ✅ @wambugucoder
+  eval: "tathmini"
+    # ✅ @wambugucoder
+  exec: "tekeleza"
+    # ✅ @wambugucoder
+  filter: "chuja"
+    # ✅ @wambugucoder
+  float: "elea"
+    # ✅ @wambugucoder
+  format: "muundo"
+    # ✅ @wambugucoder
+  frozenset: "waliohifadhiwa"
+    # ✅ @wambugucoder
+  getattr: "pata-sifa"
+    # ✅ @wambugucoder
+  globals: "ulimwengu"
+    # ✅ @wambugucoder
+  hasattr: "ina-sifa"
+    # ✅ @wambugucoder
+  hash: "hash"
+    # ✅ @wambugucoder
+  help: "saidia"
+    # ✅ @wambugucoder
+  hex: "hex"
+    # ✅ @wambugucoder
+  id: "kitambulisho"
+    # ✅ @wambugucoder
+  input: "pembejeo"
+    # ✅ @wambugucoder
+  int: "nambari"
+    # ✅ @wambugucoder
+  isinstance: "mfano"
+    # ✅ @wambugucoder
+  issubclass: "darasa-ndogo"
+    # ✅ @wambugucoder
+  iter: "mara-kwa-mara"
+    # ✅ @wambugucoder
+  len: "urefu"
+    # ✅ @wambugucoder
+  list: "orodha"
+    # ✅ @wambugucoder
+  locals: "wenyeji"
+    # ✅ @wambugucoder
+  map: "ramani"
+    # ✅ @wambugucoder
+  max: "upeo"
+    # ✅ @wambugucoder
+  memoryview: "mtazamo-wa-kumbukumbu"
+    # ✅ @wambugucoder
+  min: "kiwango-cha-chini"
+    # ✅ @wambugucoder
+  next: "ijayo"
+    # ✅ @wambugucoder
+  object: "kitu"
+    # ✅ @wambugucoder
+  oct: "oct"
+    # ✅ @wambugucoder
+  open: "fungua"
+    # ✅ @wambugucoder
+  ord: "utaratibu"
+    # ✅ @wambugucoder
+  pow: "nguvu"
+    # ✅ @wambugucoder
+  print: "chapisha"
+    # ✅ @wambugucoder
+  property: "mali"
+    # ✅ @wambugucoder
+  range: "masafa"
+    # ✅ @wambugucoder
+  repr: "repr"
+    # ✅ @wambugucoder
+  reversed: "geuza-nyuma"
+    # ✅ @wambugucoder
+  round: "raundi"
+    # ✅ @wambugucoder
+  set: "seti"
+    # ✅ @wambugucoder
+  setattr: "weka-sifa"
+    # ✅ @wambugucoder
+  slice: "kipande"
+    # ✅ @wambugucoder
+  sorted: "pangwa"
+    # ✅ @wambugucoder
+  staticmethod: "njia-tuli"
+    # ✅ @wambugucoder
+  str: "str"
+    # ✅ @wambugucoder
+  sum: "jumla"
+    # ✅ @wambugucoder
+  super: "super"
+    # ✅ @wambugucoder
+  tuple: "tuple"
+    # ✅ @wambugucoder
+  type: "aina"
+    # ✅ @wambugucoder
+  vars: "vars"
+    # ✅ @wambugucoder
+  zip: "bana"
+    # ✅ @wambugucoder
+  __import__: "_agiza_"
+    # ✅ @wambugucoder
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: "jina-mbadala"
+and: "na"
+begin: "anza"
+break: "vunja"
+case: "kisa"
+class: "darasa"
+def: "fanya"
+defined?: "imefafanuliwa?"
+do: "fanya"
+else: "au"
+elsif: "au-kama"
+end: "maliza"
+ensure: "hakikisha"
+false: "uwongo"
+for: "kwa"
+if: "kama"
+in: "katika"
+module: "moduli"
+next: "fuata"
+nil: "siyo"
+not: "si"
+or: "au"
+redo: "rudia"
+rescue: "okoa"
+retry: "jaribu-tena"
+return: "rejesha"
+self: "mwenyewe"
+super: "juu"
+then: "kisha"
+true: "kweli"
+undef: "batilisha"
+unless: "isipokuwa"
+until: "mpaka"
+when: "pale"
+while: "wakati"
+yield: "toa"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: "muhtasari"
+alignof: "alinio_la"
+as: "kama"
+become: "kuwa"
+box: "sanduku"
+break: "vunja"
+const: "daima"
+continue: "endelea"
+crate: "kizibo"
+do: "fanya"
+else: "vinginevyo"
+enum: "sura"
+extern: "nje"
+false: "uwongo"
+final: "mwisho"
+fn: "fn"
+for: "kwa"
+if: "kama"
+impl: "utekelezaji"
+in: "katika"
+let: "ruhusu"
+loop: "rudia"
+macro: "makro"
+match: "sawa"
+mod: "mod"
+move: "hamisha"
+mut: "geuza"
+offsetof: "eno_la"
+override: "pindua"
+priv: "binafsi"
+proc: "prosedua"
+pub: "wazi"
+pure: "safi"
+ref: "taja_upya"
+return: "rejesha"
+Self: "Nafsi"
+self: "nafsi"
+sizeof: "ukubwa_wa"
+static: "tuli"
+struct: "muundo"
+super: "juu"
+trait: "nasaba"
+true: "kweli"
+type: "aina"
+typeof: "aina_ya"
+unsafe: "bila_usalama"
+unsized: "isio_ainishwa"
+use: "tumia"
+virtual: "wakilishi"
+where: "ambapo"
+while: "wakati"
+yield: "zaa"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/ur.yml
+++ b/locale/ur.yml
@@ -1,0 +1,2024 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "ur"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "غلط"
+    # ✅ @nooras
+    # ✅ @sarr266
+  None: "کُچھ نہیں"
+    # ✅ @nooras
+    # ❓ @sarr266 (ندارد)
+  True: "صحیح"
+    # ✅ @nooras
+    # ✅ @sarr266 
+  and: "اور"
+    # ✅ @nooras
+    # ✅ @sarr266
+  as: "جیسا کہ"
+    # ✅ @nooras
+    # ❓ @sarr266 (بطور)
+  assert: "دعویٰ"
+    # ✅ @nooras
+    # ✅ @sarr266
+  async: "غیر متزلزل"
+    # ✅ @nooras
+    # ❓ @sarr266 (نا ہم وقت)
+  await: "انتظار"
+    # ✅ @nooras
+    # ✅ @sarr266
+  break: "توڑ"
+    # ✅ @nooras
+    # ✅ @sarr266
+  class: "کلاس"
+    # ✅ @nooras
+    # ❓ @sarr266 (طبقہ)
+  continue: "جاری رہے"
+    # ✅ @nooras
+    # ❓ @sarr266 (can be simplified to: جاری)
+  def: "واضح"
+    # ✅ @nooras
+    # ❓ @sarr266 (تعریف)
+  del: "مٹانا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  elif: "ورنہ اگر"
+    # ✅ @nooras
+    # ✅ @sarr266
+  else: "ورنہ"
+    # ✅ @nooras
+    # ✅ @sarr266
+  except: "سوائے"
+    # ✅ @nooras
+    # ✅ @sarr266
+  finally: "آخر"
+    # ✅ @nooras
+    # ❓ @sarr266 (آخرکار)
+  for: "کے لیے"
+    # ✅ @nooras
+    # ❓ @sarr266 (ہر)
+  from: "سے"
+    # ✅ @nooras
+    # ✅ @sarr266
+  global:  "عالم"
+    # ✅ @nooras
+    # ❓ @sarr266 (عالمی)
+  if: "اگر"
+    # ✅ @nooras
+    # ✅ @sarr266
+  import: "درآمد"
+    # ✅ @nooras
+    # ✅ @sarr266
+  in: "اندر"
+    # ✅ @nooras
+    # ✅ @sarr266
+  is: "ہے"
+    # ✅ @nooras
+    # ✅ @sarr266
+  lambda: "لیمبڈا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  nonlocal: "غیر مقامی"
+    # ✅ @nooras
+    # ✅ @sarr266
+  not: "نہیں"
+    # ✅ @nooras
+    # ✅ @sarr266
+  or: "یا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  pass: "پاس"
+    # ✅ @nooras
+    # ❓ @sarr266 (گزر)
+  raise: "اُٹھانا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  return: "واپس"
+    # ✅ @nooras
+    # ✅ @sarr266
+  try: "کوشش"
+    # ✅ @nooras
+    # ✅ @sarr266
+  while: "جبکہ"
+    # ✅ @nooras
+    # ❓ @sarr266 (جبتک)
+  for: "کے لیے"
+    # ✅ @sarr266
+  with: "کے ساتھ"
+    # ✅ @nooras
+    # ✅ @sarr266
+  yield: "پیدا"
+    # ✅ @nooras
+    # ✅ @sarr266
+
+# << Built-In Functions >>
+
+  abs: "مطلق"
+    # ✅ @nooras
+    # ✅ @sarr266
+  all: "سب"
+    # ✅ @nooras
+    # ✅ @sarr266
+  any: "کوئی"
+    # ✅ @nooras
+    # ✅ @sarr266
+  ascii: "ascii"
+    # ❓ @nooras Fullform of ascii in URDU is "امریکی معیاری رمز براۓ اطلاعاتی تبادلہ"
+    # ❓ @sarr266 (امریکی معیاری رمز برائے اطلاعاتی تبادلہ = امرات)
+  bin: "بائنری"
+    # ✅ @nooras
+    # ✅ @sarr266 
+  bool: "بولین"
+    # ✅ @nooras
+    # ❓ @sarr266 (بوليائی)
+  breakpoint: "بریک پوائنٹ"
+    # ✅ @nooras
+    # ✅ @sarr266 
+  bytearray: "بائٹ ایرے"
+    # ✅ @nooras
+    # ✅ @sarr266 
+  bytes: "بائٹس"
+    # ✅ @nooras
+    # ✅ @sarr266 
+  callable: "قابل طلب"
+    # ✅ @nooras
+    # ✅ @sarr266 
+  chr: "حروف"
+    # ✅ @nooras
+    # ❓ @sarr266 (حرف)
+  classmethod: "کلاس کا طریقہ"
+    # ❓ @nooras another option could be "کلاس ترتیب"
+    # ❓ @sarr266 (طبقاتی طریقہ)
+  compile: "تالیف کرنا"
+    # ✅ @nooras
+    # ❓ @sarr266 (can be simplified to: تالیف)
+  complex: "پیچیدہ"
+    # ✅ @nooras
+    # ❓ @sarr266 (ملتف)
+
+  delattr: "صفعت مٹانا"
+    # ❓ @nooras another option could be "خاصیت مٹانا"
+    # ✅ @sarr266 (both options are fine: صفت مٹانا and خاصیت مٹانا)
+  dict: "لغت"
+    # ✅ @nooras
+    # ✅ @sarr266
+  dir: "ڈائریکٹری"
+    # ✅ @nooras
+    # ✅ @sarr266
+  divmod: "تقسیم ذریب"
+    # ✅ @nooras
+    # ❓ @sarr266 (تقسیم باقی)
+  enumerate: "گننا"
+    # ✅ @nooras
+    # ❓ @sarr266 (شمار)
+  eval: "حساب"
+    # ✅ @nooras
+    # ✅ @sarr266
+  exec: "عمل میں لانا"
+    # ✅ @nooras
+    # ❓ @sarr266 (اجرا)
+  filter: "تَقطیر"
+    # ❓ @nooras another option could be "فلٹر"
+    # ❓ @sarr266 (چھان)
+  float: "فلوٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (اعشاری)
+  format: "فارمیٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (another option: ہیئت)
+  frozenset: "فروزن سیٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (جامد_مجموعہ)
+  getattr: "صفعت حاصل کرنا"
+    # ✅ @nooras
+    # ❓ @sarr266(can be simplified to: حاصل صفت)
+  globals: "عالمی"
+    # ✅ @nooras
+    # ❓ @sarr266 (عالم)
+  hasattr: "صفعت ہے"
+    # ✅ @nooras
+    # ❓ @sarr266(موجود صفت)
+  hash: "ہیش"
+    # ✅ @nooras
+    # ✅ @nooras
+  help: "مدد"
+    # ✅ @nooras
+    # ✅ @sarr266
+  hex: "ہیکس"
+    # ✅ @nooras
+    # ✅ @sarr266
+  id: "آئی ڈی"
+    # ✅ @nooras
+    # ❓ @sarr266 (شناخت)
+  input: "ان پٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (داخلہ)
+  int: "اِنٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (عدد)
+  isinstance: "مثال ہے"
+    # ✅ @nooras
+    # ❓ @sarr266 (a better option: نمونہ ہے)
+  issubclass: " سب کلاس ہے"
+    # ✅ @nooras
+    # ❓ @sarr266 (ذیلی طبقہ ہے)
+  iter: "دہرانا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  len: "لمبائی"
+    # ✅ @nooras
+    # ✅ @sarr266
+  list: "فہرست"
+    # ✅ @nooras
+    # ✅ @sarr266
+  locals: "مقامی"
+    # ✅ @nooras
+    # ✅ @sarr266
+  map: "نقشہ"
+    # ✅ @nooras
+    # ❓ @sarr266 (نقشہ means chart, outline, map. Replacement: اطلاق ,اطلاق means application)
+  max: "اعلیٰ"
+    # ❓ @nooras another option could be "زیادہ سے زیادہ"
+    # ❓ @sarr266 (زیادہ_سے_زیادہ)
+  memoryview: "میموری ویو"
+    # ✅ @nooras
+    # ✅ @sarr266
+  min: "ادنیٰ"
+    # ❓ @nooras another option could be "کم از کم"
+    # ❓ @sarr266 (کم_از_کم)
+  next: "اگلا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  object: "اوبجکٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (شے)
+  oct: "آکٹل"
+    # ✅ @nooras
+    # ✅ @sarr266
+  open: "کھلا"
+    # ✅ @nooras
+    # ❓ @sarr266 (کھول)
+  ord: "آرد"
+    # ❓ @nooras another option could be "ord"
+    # ❓ @sarr266 (ترتیب)
+  pow: "پاؤ"
+    # ✅ @nooras
+    # ❓ @sarr266 (طاقت)
+  print: "پرنٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (لکھو)
+  property: "صفت"
+    # ✅ @nooras
+    # ❓ @sarr266 (خاصیت)
+  range: "حد"
+    # ✅ @nooras
+    # ❓ @sarr266 (سلسلہ)
+  repr: "repr"
+    # ✅ @nooras
+    # ✅ @sarr266
+  reversed: "الٹا"
+    # ✅ @nooras
+    # ❓ @sarr266 (پلٹ)
+  round: "گول"
+    # ✅ @nooras
+    # ❓ @sarr266 (other options: عدد مکمل or قریبی عدد)
+  set: "سیٹ"
+    # ✅ @nooras
+    # ❓ @sarr266 (other option: مجموعہ)
+  setattr: "صفعت مقدرکرنا"
+    # ✅ @nooras
+    # ❓ @sarr266 (can be simplified to: مقرر صفت)
+  slice: "ٹکڑا"
+    # ✅ @nooras
+    # ✅ @sarr266
+  sorted: "ترتیب وار"
+    # ✅ @nooras
+    # ✅ @sarr266
+  staticmethod: "سٹیٹک طریقہ"
+    # ✅ @nooras
+    # ❓ @sarr266 (ساکن طریقہ)
+  str: "سٹرنگ"
+    # ✅ @nooras
+    # ❓ @sarr266 (string: ڈوری, str: ڈور)
+  sum: "کُل"
+    # ✅ @nooras
+    # ❓ @sarr266 (جمع)
+  super: "سُپر"
+    # ✅ @nooras
+    # ✅ @sarr266
+  tuple: "ٹپل"
+    # ✅ @nooras
+    # ✅ @sarr266
+  type: "قسم"
+    # ✅ @nooras
+    # ✅ @sarr266
+  vars: "متغیر"
+    # ✅ @nooras
+    # ✅ @sarr266
+  zip: "زپ"
+    # ✅ @nooras
+    # ❓ @sarr266 (another option: ضم)
+  __import__: "__درآمد__"
+    # ✅ @nooras
+    # ✅ @sarr266
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>


### PR DESCRIPTION
## Why

PRs [#321](https://github.com/legesher/legesher-translations/pull/321) (sarr266) and [#305](https://github.com/legesher/legesher-translations/pull/305) (Collins Koech) were merged with credit comments earlier today, but their base branches were the stale 2020 feature branches (`urdu-translation` and `swahili-translation`), not main. So the "Merged" badges are green on GitHub, the contributors are credited, and the commit ancestry is in main — but their file content never landed on main's tree.

This PR cherry-picks the files changed in each PR so the archive's final main snapshot actually carries both contributors' work.

## Files added

### `locale/ur.yml` — sarr266 (PR #321)

107-line addition (zero deletions) — sarr266 layered her ✅/❓ review votes alongside @nooras's existing ones for every Urdu keyword translation. She ✅-agrees with most and ❓-suggests alternatives for others (e.g., `ندارد` for `None`, `بطور` for `as`, `نا ہم وقت` for `async`, `طبقہ` for `class`, `تعریف` for `def`, `آخرکار` for `finally`, `ہر` for `for`).

This is pure community review content — the kind of thing the [review-history PR #323](https://github.com/legesher/legesher-translations/pull/323) captures for Spanish and German. Nothing removed; everything added.

### `locale/sw.yml` — Collins Koech (PR #305)

Despite the PR title "Ruby Rust translation", the file is Collins adding **Swahili translations for Ruby keywords** in the repo's multi-language locale file. Genuine East African contributor work:

| Ruby keyword | Swahili translation |
|---|---|
| `alias` | `jina-mbadala` (alternative name) |
| `and` | `na` |
| `begin` | `anza` |
| `break` | `vunja` |
| `class` | `darasa` |
| `def` | `fanya` |
| `ensure` | `hakikisha` |
| `module` | `moduli` |
| `return` | `rejesha` |
| `while` | `wakati` |

…plus ~25 more. Fills in the `LANGUAGE: RUBY / << Keywords >>` section of `locale/sw.yml`.

## Intentionally excluded from PR #305

`package-lock.json` churn (+2094/-1063 lines) — dependency lockfile regeneration noise from Collins's fork, not meaningful for an archived repo.

## Review note

Main previously had no `locale/` directory at all — its state goes back further than the translation reorganization. This PR creates the `locale/` path with just these two files. That's intentional; the other ~30 language YAMLs from deleted sibling branches are NOT being brought here. The scope is strictly "files that these two contributors added in their open PRs".

Signed-off-by: Madison (Pfaff) Edgar <7844510+madiedgar@users.noreply.github.com>