### PR TITLE
docs(archive): credit @sarr266 + @collinskoech11 as contributors [CORE-673]

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -769,6 +769,25 @@
       "contributions": [
         "review"
       ]
+    },
+    {
+      "login": "sarr266",
+      "name": "sarr266",
+      "avatar_url": "https://avatars.githubusercontent.com/u/104586011?v=4",
+      "profile": "https://github.com/sarr266",
+      "contributions": [
+        "review",
+        "translation"
+      ]
+    },
+    {
+      "login": "collinskoech11",
+      "name": "Collins Koech",
+      "avatar_url": "https://avatars.githubusercontent.com/u/35452377?v=4",
+      "profile": "https://github.com/collinskoech11",
+      "contributions": [
+        "translation"
+      ]
     }
   ],
   "contributorsPerLine": 7


### PR DESCRIPTION
## Why

Following [PR #324](https://github.com/legesher/legesher-translations/pull/324) bringing @sarr266's Urdu review and @collinskoech11's Swahili/Ruby translations onto main's tree, this PR formally adds both as contributors in `.all-contributorsrc`. Git co-author trailers on the commit also credit them as joint authors for the all-contributors bot and GitHub's co-author badges.

## Changes

Two new entries in `.all-contributorsrc`:

- **@sarr266** — roles `review` + `translation`
  - `review`: Added ✅/❓ votes on top of @nooras's existing Urdu keyword translations in `locale/ur.yml` (PR #321)
  - `translation`: Suggested alternative translations where she disagreed (e.g., `ندارد` for `None`, `بطور` for `as`, `نا ہم وقت` for `async`, `طبقہ` for `class`, `تعریف` for `def`)

- **@collinskoech11 (Collins Koech)** — role `translation`
  - Added Swahili translations for Ruby keywords in `locale/sw.yml` (PR #305): `alias`→`jina-mbadala`, `class`→`darasa`, `def`→`fanya`, `return`→`rejesha`, and ~30 others.

Total contributors in file goes from 83 → 85.

## Follow-up

This is part of the broader CONTRIBUTORS.md composition tracked on [CORE-673](https://linear.app/legesher/issue/CORE-673). A separate PR will regenerate the contributor table in `README.md` via `npx all-contributors-cli generate` once the final list is complete. Since we're adding folks incrementally, I'm deferring the regeneration until everyone is in.

Signed-off-by: Madison (Pfaff) Edgar <7844510+madiedgar@users.noreply.github.com>
Co-Authored-By: sarr266 <104586011+sarr266@users.noreply.github.com>
Co-Authored-By: Collins Koech <35452377+collinskoech11@users.noreply.github.com>