### PR TITLE
docs(archive): prepend deprecation banner to README [CORE-673]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+> ## ⚠️ This repository is deprecated
+>
+> **Legesher's translation work has moved to the monorepo:** [**Legesher/legesher/libs/i18n/**](https://github.com/legesher/legesher/tree/main/libs/i18n)
+>
+> - **51 language packs** (experimental, community validation ongoing) — [browse them](https://github.com/legesher/legesher/tree/main/libs/i18n/language-packs/python)
+> - **Install:** `pip install legesher-i18n`
+> - **Contribute:** open PRs, issues, and translation reviews on the [monorepo](https://github.com/legesher/legesher)
+>
+> This repo is kept as a historical record. The **[149 contributors](CONTRIBUTORS.md)** whose work established Legesher's translation infrastructure are credited here. Full line-by-line community review discussions for Spanish and German translations are preserved in [`docs/review-history/`](docs/review-history/). Browse, fork, learn — but please direct new contributions to the monorepo.
+>
+> ---
+
 <img src="/lib/images/README-EggPeggy.png" align="center"/>
 
 <h1 align="center">Legesher Translations</h1>


### PR DESCRIPTION
## Why

Prepend a clear deprecation banner to `README.md` so visitors to the repo immediately see where active Legesher translation work has moved. This is a pure content-add — no other README lines change.

Per project decision (2026-04-19), the repo is **NOT being archived at this time**. The banner declares the deprecation but the repo stays active — stars and forks continue to work, existing issues/PRs remain navigable.

## What's in the banner

Brief, link-heavy, friendly:

- Top-line callout: "⚠️ This repository is deprecated"
- Link to the monorepo's `libs/i18n/` (the active home)
- Language pack browsing link + pip install instructions + contribute-here link
- Acknowledgment of the 149 contributors (links to `CONTRIBUTORS.md`)
- Pointer to preserved review-history docs

## Relation to CORE-852

This PR also produces the **first rendering of the banner template** that CORE-852 will reuse for the other legacy Legesher org repos:

- `tree-sitter-legesher-python` → points at monorepo `libs/core/`
- `language-legesher-python` → points at monorepo
- `legesher-docs` → points at docs.legesher.io

Each repo gets the same banner structure with the appropriate destination link.

## Links

Banner references:

- [`CONTRIBUTORS.md`](CONTRIBUTORS.md) — **pending in PR #326** (open). Link will resolve cleanly once that PR merges; until then it's a broken link on main. Harmless because a deprecated repo can tolerate a transient broken link, but worth noting.
- [`docs/review-history/`](docs/review-history/) — already on main (via merged [PR #323](https://github.com/legesher/legesher-translations/pull/323))
- The monorepo `libs/i18n/` — active, live

## Intentionally NOT in this PR

- **Archive action** — explicitly deferred; repo stays active
- **Final legacy release** — also deferred
- **Branch cleanup** — deferred

Signed-off-by: Madison (Pfaff) Edgar <7844510+madiedgar@users.noreply.github.com>