### PR TITLE
feat(translations): restore 29 language YAML files onto main [CORE-673]

### DIFF
--- a/locale/ar.yml
+++ b/locale/ar.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "ar"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "ملحوظة"
+  INFO: "معلومة"
+  IDEA: "فكرة"
+  DEBUG: "تصحيح"
+  REMOVE: "ازالة"
+  OPTIMIZE: "تحسين"
+  REVIEW: "مراجعة"
+  HACK: "اختراق"
+  UNDONE: "لم ينتهى"
+  TODO: "عليه ان يتم"
+  REFACTOR: "تعديل"
+  DEPRECATED: "مهمل"
+  TASK: "مهمة"
+  CHGME: ""
+  NOTREACHED: "لا يوصل اليه"
+  WTF: ""
+  BUG: "مشكلة"
+  ERROR: "خطأ"
+  OMG: ""
+  ERR: "خطأ"
+  OMFGRLY: ""
+  WARNING: "تحذير"
+  WARN: "يحذر"
+  BROKEN: "مكسور"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "حالة"
+do: "افعل"
+done: "تم"
+elif: "في حالة"
+else: "في حالة اي شئ اخر"
+esac: ""
+fi: ""
+for: "لكل"
+function: "دالة"
+if: "اذا"
+in: "في"
+select: "اختر"
+then: "اذا"
+time: "وقت"
+until: "حتى"
+while: "طالما"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "الى"
+double: "رقم عشري كبير"
+int: "رقم صحيح"
+struct: "منشأة"
+break: "ايقاف"
+else: "غير ذلك"
+long: "رقم طويل"
+switch: "تحويل"
+case: "في حالة"
+enum: ""
+register: "تسجيل"
+typedef: "تحديد النوع"
+char: "رمز"
+extern: "خارجي"
+return: "رجوع"
+union: "اتحاد"
+const: "ثابت"
+float: "رقم عشري صغير"
+short: "رقم صغير"
+unsigned: "موجب"
+continue: "اكمل"
+for: "لكل"
+signed: "موجب لو سالب"
+void: "فراغ"
+default: "افتراضي"
+goto: "اذهب الى"
+sizeof: "حجم"
+volatile: "ملف متبخر"
+do: "قم ب"
+if: "اذا"
+static: "ساكن"
+while: "طالما"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" # Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" # Specifies the alignment for items inside a flexible container
+align-self: "" #  Specifies the alignment for selected items inside a flexible container
+all: "" # Resets all properties (except unicode-bidi and direction)
+animation: "" # A shorthand property for all the animation-* properties
+animation-delay: "" # Specifies a delay for the start of an animation
+animation-direction: "" # Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #  Specifies how long an animation should take to complete one cycle
+animation-mode: "" #  Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" # Specifies the number of times an animation should be played
+animation-name: "" #  Specifies a name for the @keyframes animation
+animation-state: "" # Specifies whether the animation is running or paused
+animation-function: "" #  Specifies the speed curve of an animation
+backface-visibility: "" # Defines whether or not the back face of an element should be visible when facing the user
+background: "" #  A shorthand property for all the background-* properties
+background-attachment: "" # Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" # Specifies the blending mode of each background layer (color/image)
+background-clip: "" # Defines how far the background (color or image) should extend within an element
+background-color: "" #  Specifies the background color of an element
+background-image: "" #  Specifies one or more background images for an element
+background-origin: "" # Specifies the origin position of a background image
+background-position: "" # Specifies the position of a background image
+background-repeat: "" # Sets if/how a background image will be repeated
+background-size: "" # Specifies the size of the background images
+border: "" #  A shorthand property for border-width, border-style and border-color
+border-bottom: "" # A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #  Sets the color of the bottom border
+border-radius: "" # Defines the radius of the border of the bottom-left corner
+border-radius: "" # Defines the radius of the border of the bottom-right corner
+border-style: "" #  Sets the style of the bottom border
+border-width: "" #  Sets the width of the bottom border
+border-collapse: "" # Sets whether table borders should collapse into a single border or be separated
+border-color: "" #  Sets the color of the four borders
+border-image: "" #  A shorthand property for all the border-image-* properties
+border-outset: "" # Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" # Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #  Specifies how to slice the border image
+border-source: "" # Specifies the path to the image to be used as a border
+border-width: "" #  Specifies the width of the border image
+border-left: "" # A shorthand property for all the border-left-* properties
+border-color: "" #  Sets the color of the left border
+border-style: "" #  Sets the style of the left border
+border-width: "" #  Sets the width of the left border
+border-radius: "" # A shorthand property for the four border-*-radius properties
+border-right: "" #  A shorthand property for all the border-right-* properties
+border-color: "" #  Sets the color of the right border
+border-style: "" #  Sets the style of the right border
+border-width: "" #  Sets the width of the right border
+border-spacing: "" #  Sets the distance between the borders of adjacent cells
+border-style: "" #  Sets the style of the four borders
+border-top: "" #  A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #  Sets the color of the top border
+border-radius: "" # Defines the radius of the border of the top-left corner
+border-radius: "" # Defines the radius of the border of the top-right corner
+border-style: "" #  Sets the style of the top border
+border-width: "" #  Sets the width of the top border
+border-width: "" #  Sets the width of the four borders
+bottom: "" #  Sets the elements position, from the bottom of its parent element
+box-break: "" # Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #  Attaches one or more shadows to an element
+box-sizing: "" #  Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" # Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #  Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #  Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #  Specifies the placement of a table caption
+caret-color: "" # Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #  Specifies the character encoding used in the style sheet
+clear: "" # Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #  Clips an absolutely positioned element
+color: "" # Sets the color of text
+column-count: "" #  Specifies the number of columns an element should be divided into
+column-fill: "" # Specifies how to fill columns, balanced or not
+column-gap: "" #  Specifies the gap between the columns
+column-rule: "" # A shorthand property for all the column-rule-* properties
+column-color: "" #  Specifies the color of the rule between columns
+column-style: "" #  Specifies the style of the rule between columns
+column-width: "" #  Specifies the width of the rule between columns
+column-span: "" # Specifies how many columns an element should span across
+column-width: "" #  Specifies the column width
+columns: "" # A shorthand property for column-width and column-count
+content: "" # Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" # Increases or decreases the value of one or more CSS counters
+counter-reset: "" # Creates or resets one or more CSS counters
+cursor: "" #  Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" # Specifies the text direction/writing direction
+display: "" # Specifies how a certain HTML element should be displayed
+empty-cells: "" # Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #  Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #  A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #  Specifies the initial length of a flexible item
+flex-direction: "" #  Specifies the direction of the flexible items
+flex-flow: "" # A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" # Specifies how much the item will grow relative to the rest
+flex-shrink: "" # Specifies how the item will shrink relative to the rest
+flex-wrap: "" # Specifies whether the flexible items should wrap or not
+float: "" # Specifies whether or not a box should float
+font: "" #  A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #  A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" # Specifies the font family for text
+font-settings: "" # Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #  Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #  Controls the usage of the kerning information (how letters are spaced)
+font-override: "" # Controls the usage of language-specific glyphs in a typeface
+font-size: "" # Specifies the font size of text
+font-adjust: "" # Preserves the readability of text when font fallback occurs
+font-stretch: "" #  Selects a normal, condensed, or expanded face from a font family
+font-style: "" #  Specifies the font style for text
+font-synthesis: "" #  Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #  Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" # Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" # Controls the usage of alternate glyphs for capital letters
+font-asian: "" #  Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #  Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #  Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" # Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" # Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" # Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #  Specifies a default column size
+grid-flow: "" # Specifies how auto-placed items are inserted in the grid
+grid-rows: "" # Specifies a default row size
+grid-column: "" # A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #  Specifies where to end the grid item
+grid-gap: "" #  Specifies the size of the gap between columns
+grid-start: "" #  Specifies where to start the grid item
+grid-gap: "" #  A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #  A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #  Specifies where to end the grid item
+grid-gap: "" #  Specifies the size of the gap between rows
+grid-start: "" #  Specifies where to start the grid item
+grid-template: "" # A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #  Specifies how to display columns and rows, using named grid items
+grid-columns: "" #  Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" # Specifies the size of the rows in a grid layout
+hanging-punctuation: "" # Specifies whether a punctuation character may be placed outside the line box
+height: "" #  Sets the height of an element
+hyphens: "" # Sets how to split words to improve the layout of paragraphs
+image-rendering: "" # Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" # Allows you to import a style sheet into another style sheet
+isolation: "" # Defines whether an element must create a new stacking content
+justify-content: "" # Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #  Specifies the animation code
+left: "" #  Specifies the left position of a positioned element
+letter-spacing: "" #  Increases or decreases the space between characters in a text
+line-break: "" #  Specifies how/if to break lines
+line-height: "" # Sets the line height
+list-style: "" #  Sets all the properties for a list in one declaration
+list-image: "" #  Specifies an image as the list-item marker
+list-position: "" # Specifies the position of the list-item markers (bullet points)
+list-type: "" # Specifies the type of list-item marker
+margin: "" #  Sets all the margin properties in one declaration
+margin-bottom: "" # Sets the bottom margin of an element
+margin-left: "" # Sets the left margin of an element
+margin-right: "" #  Sets the right margin of an element
+margin-top: "" #  Sets the top margin of an element
+max-height: "" #  Sets the maximum height of an element
+max-width: "" # Sets the maximum width of an element
+@media: "" #  Sets the style rules for different media types/devices/sizes
+min-height: "" #  Sets the minimum height of an element
+min-width: "" # Sets the minimum width of an element
+mix-mode: "" #  Specifies how an element's content should blend with its direct parent background
+object-fit: "" #  Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" # Specifies the alignment of the replaced element inside its box
+opacity: "" # Sets the opacity level for an element
+order: "" # Sets the order of the flexible item, relative to the rest
+orphans: "" # Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" # A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" # Sets the color of an outline
+outline-offset: "" #  Offsets an outline, and draws it beyond the border edge
+outline-style: "" # Sets the style of an outline
+outline-width: "" # Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" # Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #  Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #  Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" # A shorthand property for all the padding-* properties
+padding-bottom: "" #  Sets the bottom padding of an element
+padding-left: "" #  Sets the left padding of an element
+padding-right: "" # Sets the right padding of an element
+padding-top: "" # Sets the top padding of an element
+page-after: "" #  Sets the page-break behavior after an element
+page-before: "" #: "" # Sets the page-break behavior before an element
+page-inside: "" #: "" # Sets the page-break behavior inside an element
+perspective: "" # Gives a 3D-positioned element some perspective
+perspective-origin: "" #  Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #  Defines whether or not an element reacts to pointer events
+position: "" #  Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #  Sets the type of quotation marks for embedded quotations
+resize: "" #  Defines if (and how) an element is resizable by the user
+right: "" # Specifies the right position of a positioned element
+scroll-behavior: "" # Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #  Specifies the width of a tab character
+table-layout: "" #  Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #  Specifies the horizontal alignment of text
+text-last: "" # Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #  Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" # Specifies the decoration added to text
+text-color: "" #  Specifies the color of the text-decoration
+text-line: "" # Specifies the type of line in a text-decoration
+text-style: "" #  Specifies the style of the line in a text decoration
+text-indent: "" # Specifies the indentation of the first line in a text-block
+text-justify: "" #  Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: ""  #Defines the orientation of the text in a line
+text-overflow: "" #: ""   #Specifies what should happen when text overflows the containing element
+text-shadow: "" #: ""   #Adds shadow to text
+text-transform: "" #: ""  #Controls the capitalization of text
+text-position: "" #: "" # Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" # Specifies the top position of a positioned element
+transform: "" #: "" # Applies a 2D or 3D transformation to an element
+transform-origin: "" #  Allows you to change the position on transformed elements
+transform-style: "" # Specifies how nested elements are rendered in 3D space
+transition: "" #  A shorthand property for all the transition-* properties
+transition-delay: "" #  Specifies when the transition effect will start
+transition-duration: "" # Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" # Specifies the name of the CSS property the transition effect is for
+transition-function: "" # Specifies the speed curve of the transition effect
+unicode-bidi: "" #  Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" # Specifies whether the text of an element can be selected
+vertical-align: "" #  Sets the vertical alignment of an element
+visibility: "" #  Specifies whether or not an element is visible
+white-space: "" # Specifies how white-space inside an element is handled
+widows: "" #  Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" # Sets the width of an element
+word-break: "" #  Specifies how words should break when reaching the end of a line
+word-spacing: "" #  Increases or decreases the space between words in a text
+word-wrap: "" # Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #  Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" # Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #  Defines the document type
+a: "" # Defines a hyperlink
+abbr: "" #  Defines an abbreviation or an acronym
+acronym: "" # Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" # Defines contact information for the author/owner of a document
+applet: "" #  Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #  Defines an area inside an image-map
+article: "" # Defines an article
+aside: "" # Defines content aside from the page content
+audio: "" # Defines sound content
+b: "" # Defines bold text
+base: "" #  Specifies the base URL/target for all relative URLs in a document
+basefont: "" #  Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" # Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" # Overrides the current text direction
+big: "" # Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #  Defines a section that is quoted from another source
+body: "" #  Defines the document's body
+br: "" #  Defines a single line break
+button: "" #  Defines a clickable button
+canvas: "" #  Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" # Defines a table caption
+center: "" #  Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #  Defines the title of a work
+code: "" #  Defines a piece of computer code
+col: "" # Specifies column properties for each column within a <colgroup> element
+colgroup: "" #  Specifies a group of one or more columns in a table for formatting
+data: "" #  Links the given content with a machine-readable translation
+datalist: "" #  Specifies a list of pre-defined options for input controls
+dd: "" #  Defines a description/value of a term in a description list
+del: "" # Defines text that has been deleted from a document
+details: "" # Defines additional details that the user can view or hide
+dfn: "" # Represents the defining instance of a term
+dialog: "" #  Defines a dialog box or window
+dir: "" # Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" # Defines a section in a document
+dl: "" #  Defines a description list
+dt: "" #  Defines a term/name in a description list
+em: "" #  Defines emphasized text
+embed: "" # Defines a container for an external (non-HTML) application
+fieldset: "" #  Groups related elements in a form
+figcaption: "" #  Defines a caption for a <figure> element
+figure: "" #  Specifies self-contained content
+font: "" #  Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #  Defines a footer for a document or section
+form: "" #  Defines an HTML form for user input
+frame: "" # Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #  Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>  Defines HTML headings
+head: "" #  Defines information about the document
+header: "" #  Defines a header for a document or section
+hr: "" #  Defines a thematic change in the content
+html: "" #  Defines the root of an HTML document
+i: "" # Defines a part of text in an alternate voice or mood
+iframe: "" #  Defines an inline frame
+img: "" # Defines an image
+input: "" # Defines an input control
+ins: "" # Defines a text that has been inserted into a document
+kbd: "" # Defines keyboard input
+label: "" # Defines a label for an <input> element
+legend: "" #  Defines a caption for a <fieldset> element
+li: "" #  Defines a list item
+link: "" #  Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #  Specifies the main content of a document
+map: "" # Defines a client-side image-map
+mark: "" #  Defines marked/highlighted text
+meta: "" #  Defines metadata about an HTML document
+meter: "" # Defines a scalar measurement within a known range (a gauge)
+nav: "" # Defines navigation links
+noframes: "" #  Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #  Defines an alternate content for users that do not support client-side scripts
+object: "" #  Defines an embedded object
+ol: "" #  Defines an ordered list
+optgroup: "" #  Defines a group of related options in a drop-down list
+option: "" #  Defines an option in a drop-down list
+output: "" #  Defines the result of a calculation
+p: "" # Defines a paragraph
+param: "" # Defines a parameter for an object
+picture: "" # Defines a container for multiple image resources
+pre: "" # Defines preformatted text
+progress: "" #  Represents the progress of a task
+q: "" # Defines a short quotation
+rp: "" #  Defines what to show in browsers that do not support ruby annotations
+rt: "" #  Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #  Defines a ruby annotation (for East Asian typography)
+s: "" # Defines text that is no longer correct
+samp: "" #  Defines sample output from a computer program
+script: "" #  Defines a client-side script
+section: "" # Defines a section in a document
+select: "" #  Defines a drop-down list
+small: "" # Defines smaller text
+source: "" #  Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #  Defines a section in a document
+strike: "" #  Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #  Defines important text
+style: "" # Defines style information for a document
+sub: "" # Defines subscripted text
+summary: "" # Defines a visible heading for a <details> element
+sup: "" # Defines superscripted text
+svg: "" # Defines a container for SVG graphics
+table: "" # Defines a table
+tbody: "" # Groups the body content in a table
+td: "" #  Defines a cell in a table
+template: "" #  Defines a template
+textarea: "" #  Defines a multiline input control (text area)
+tfoot: "" # Groups the footer content in a table
+th: "" #  Defines a header cell in a table
+thead: "" # Groups the header content in a table
+time: "" #  Defines a date/time
+title: "" # Defines a title for the document
+tr: "" #  Defines a row in a table
+track: "" # Defines text tracks for media elements (<video> and <audio>)
+tt: "" #  Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" # Defines text that should be stylistically different from normal text
+ul: "" #  Defines an unordered list
+var: "" # Defines a variable
+video: "" # Defines a video or movie
+wbr: "" # Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: خطأ‫"‬" #✅✅
+  None: "متغير لا يحمل أي قيمة" #✅, @OussamaSALAHOUELHADJ ❓ "بلا قيمة" is more abstract, what was suggested is "a none 'variable'" and what i suggested is only "none" ".
+  True: "صحيح" #✅✅
+  and: "و" #✅✅
+  as: " كلمة مفتاحية بمعنى كاف التشبية تستخدم لاعطاء اسم بديل للموديل عند تضمينها" #🤔, @OussamaSALAHOUELHADJ ❓ we can use "بدل" or "بإسم".
+  assert: "تصريح تأكيد صحة قيمة" #❓ assert: "تأكيد", @OussamaSALAHOUELHADJ ❓ "أكد"
+  async: "تشغيل كتلتين أو أكثر بشكل متوازي بدلا من متسلسل" #❓ async: "غير متزامن"
+  await: "انتظار" #✅, @OussamaSALAHOUELHADJ ❓ "ترقب" is more efficiant, (used as a verb describing the act of waiting for something).
+  break: "خروج من الحلقة" #✅, @OussamaSALAHOUELHADJ ❓ "قطع" describes the process of altering better.
+  class: "ظبقة" #❓ class: "ظبقة", @OussamaSALAHOUELHADJ ❓ "فئة" or "صنف".
+  continue: ‫"‬استمر‫"‬ #✅✅
+  def: "تعريف" #✅✅
+  del: "حذف" #✅✅
+  elif: "في حال ‫(‬الشرط‫)‬" #❓ elif: "وإلا إذا"
+  else: "في حال أي شيء آخر" #❓ else: "وإلا"
+  except: "اسثناء" #✅✅
+  finally: ‫"‬أخيرا‫"‬ #✅✅
+  for: "بداية بيان تسلسل حلقي" #❓ for: "حلقة for", @OussamaSALAHOUELHADJ ❓ "لأجل" is the best fit for "for".
+  from: "من " #✅✅
+  global:  "عمومي" #❓ global: "عام"
+  if: "إذا" #✅✅
+  import: "استيراد" #✅✅
+  in: "في" #✅✅
+  is: "هو" #✅✅
+  lambda: " تصريح لانشاء كائنات دالة جذيدة " #🤔, @OussamaSALAHOUELHADJ 🤔 The direct translation would be: "لامدا".
+  nonlocal: "غير محلي " #✅✅
+  not: "ليس" #✅✅
+  or: "أو" #✅✅
+  pass: "بيان اشارة االى كتلة فارغة من البيانات" #❓ pass: "تجاوز"
+  raise: "كلمة مفتاحية لإنشاءأو إرجاع استثناء" #❓ raise: "إرجاع استثناء", @OussamaSALAHOUELHADJ ❓ raise: "إثارة " or "رفع" is more abstract, "استثناء" means an exception which if it is used with raise, the keyword raise will be in a specific context.
+  return: "إرجاع قيمة معينة" #❓ return: "إرجاع"
+  try: " حاول، غالبا ما تستخدم في بداية كتلة استثناءات " #❓ try: "حاول"
+  while: "بيان تدوير" #❓ while: "حلقة while", @OussamaSALAHOUELHADJ ❓ "بينما" or "طالما" are two great suggestions with the same meaning as "while".
+  with: "مع" #✅✅
+  yield: "إرجاع كائن مولًد لا يحفظ في الذاكرة" #🤔❓ yield: "إرجاع", @OussamaSALAHOUELHADJ 🤔 yield: "تحقيق" is like fulfillment/execution it describes the act of finishing from something and it's ready to be out(in the case of books for example: ready to be published).
+
+# << Built-In Functions >>
+
+  abs: "قيمة مطلقة" #✅, @OussamaSALAHOUELHADJ ❓ "القيمة المطلقة" is the same suggestion but with the identifier.
+  all: "كل" #✅✅
+  any: "أي" #✅✅
+  ascii: "أسكي" #✅, @OussamaSALAHOUELHADJ 🤔 There is no clear translation for this abbreviation, "أسكي" is literal translation.
+  bin: "ثنائي"  #✅✅
+  bool: "بوولي" #❓ bool: "منطقي", @OussamaSALAHOUELHADJ 🤔 bool returns a logic value (true, false), but I'm not sure if we can use "منطقي" as a translation, "منطقي" means "logical".
+  breakpoint: "نقطة المقاطعة"  #✅, @OussamaSALAHOUELHADJ ❓ "نقطة قطع", There is a slight difference between the two words: "قطع" and "المقاطعة".
+  bytearray: "مجموعة من البايت" #❓ bytearray: "مصفوفة من البايت", @OussamaSALAHOUELHADJ 🤔 "مصفوفة" used also for matrices.
+  bytes: "قيم من البايت" #✅✅
+  callable: "دالة يمكن استدعائها" #❓ callable: "يمكن استدعائه"
+  chr: "حرف" #❓ chr: "محرف", @OussamaSALAHOUELHADJ ✅ "حرف" is correct.
+  classmethod: "دالة صنف" #✅, @OussamaSALAHOUELHADJ ❓ "نشاط صنف" or "نشاط فئة", the word "دالة" translates to "function" can be used but it doesn't describe a method (a function inside an object) it is just a general meaning of "function".
+  compile: "ترجم" #✅, @OussamaSALAHOUELHADJ ❓ "ترجم" means translate, "تجميع" means compile.
+  complex: "الجزء المركب" #✅✅
+  delattr: "إزالة خاصية" #✅, @OussamaSALAHOUELHADJ ❓ "إزالة صفة", attribute/"object variable": "صفة", mothod: "نشاط" or "دالة" which translates to "function", "خاصية" can be a method or an attribute or both, so "خواص" means the methods and the attributes of an Object/class together.
+  dict: "قاموس" #✅✅
+  dir: "إظهار خواص الكائن" #🤔🤔
+  divmod: "حساب ناتج وباقي القسمة" #✅✅
+  enumerate: "سرد" #❓ enumerate: "ترقيم", @OussamaSALAHOUELHADJ 🤔 "عد" and "إحصاء" translate to "count".
+  eval: "قييم" #❓ eval: "تقييم",  @OussamaSALAHOUELHADJ 🤔 not sure if "قييم" describes the function.
+  exec: "نفذ" #✅✅
+  filter: "نقي" #❓ filter: "منقي", @OussamaSALAHOUELHADJ ❓ filter: "ترشيح".
+  float: "كسر" #❓, @OussamaSALAHOUELHADJ ❓ "رقم عشري" means decimal number.
+  format: "تهيئة" #✅✅
+  frozenset: "مجموعة غير قابلة للتغيير" #✅, @OussamaSALAHOUELHADJ 🤔
+  getattr: "إستحضار خاصية" #✅, @OussamaSALAHOUELHADJ ❓ "إستحضار صفة".
+  globals: "القيم العمومية" #✅, @OussamaSALAHOUELHADJ ❓ "الرموز العامة" i used "الرموز" istead of "القيم" because in the definition of the function, "globals" returns "symbols".
+  hasattr: "لديه خاصية" #✅, @OussamaSALAHOUELHADJ ❓ "لديه صفة".
+  hash: "تلبيد" #❓, @OussamaSALAHOUELHADJ 🤔
+  help: "مساعدة" #✅✅
+  hex: "تحويل للنظام الستة عشري" #✅, @OussamaSALAHOUELHADJ ❓ "النظام السداسي عشري".
+  id: "هوية" #✅, @OussamaSALAHOUELHADJ ❓ "معرف" is commonly used to describe "id".
+  input: "إدخال" #✅✅
+  int: "عدد صحيح" #✅✅
+  isinstance: "من نوع" #✅
+  issubclass: "يرث من" #✅, @OussamaSALAHOUELHADJ ❓ "فئة فرعية" or "صنف فرعي".
+  iter: "مكرر" #❓ iter: "حلقة iter", @OussamaSALAHOUELHADJ ❓ "كرر" or "عد".
+  len: "طول" #✅✅
+  list: "قائمة" #✅✅
+  locals: "القيم المحلية" #✅✅
+  map: "نفذ دالة على كل من" #❓, @OussamaSALAHOUELHADJ 🤔
+  max: "أكبر" #❓ max: "الأكبر", @OussamaSALAHOUELHADJ ❓ "الحد الأقصى".
+  memoryview: "إظهار الذاكرة" #✅✅
+  min: "أصغر" #❓ min: "الأصغر", @OussamaSALAHOUELHADJ ❓ "الحد الأدنى".
+  next: "التالي" #✅✅
+  object: "الكائن" #✅✅
+  oct: "تحويل للنظام ثماني" #✅, @OussamaSALAHOUELHADJ ❓ "النظام الثماني".
+  open: "فتح" #✅✅
+  ord: "إستحضار قيمة اليونيكود" #❓ ord: "تحويل محرف لقيمته الرقمية", @OussamaSALAHOUELHADJ 🤔
+  pow: "أس" #✅✅
+  print: "طباعة" #✅✅
+  property: "خاصية" #✅, @OussamaSALAHOUELHADJ ❓ "صفة".
+  range: "مدى" #✅✅
+  repr: "إستحضار ممثل عن القيمة" #🤔
+  reversed: "معكوس" #✅✅
+  round: "تقريب" #✅, @OussamaSALAHOUELHADJ ❓ "تدوير".
+  set: "مجموعة" #✅✅
+  setattr: "ضبط خاصية" #✅, @OussamaSALAHOUELHADJ ❓ "تحديد صفة".
+  slice: "إستحضار جزء من" #❓ slice: "شريحة"
+  sorted: "مرتب" #✅✅
+  staticmethod: "دالة ثابتة" #✅✅
+  str: "تحويل القيمة إلى سلسلة من الحروف" #❓ str: "تحويل الى نص"
+  sum: "إجمع " #✅, @OussamaSALAHOUELHADJ ❓ "جمع".
+  super: "إستحضار الضالة من الفئة العظيمة" #🤔, @OussamaSALAHOUELHADJ 🤔 we can say "فئة علوية" or "صنف علوي".
+  tuple: "زوج" #❓ tuple: "مجموعة غير قابلة للتغيير"
+  type: "نوع" #✅✅
+  vars: "إستحضار خواص الكائن" #✅, @OussamaSALAHOUELHADJ ❓ "صفات".
+  zip: "إستحضار مكرر من" #🤔, @OussamaSALAHOUELHADJ 🤔
+  __import__: "إستيراد" #✅✅
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/az.yml
+++ b/locale/az.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "az"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: ""
+  None: ""
+  True: ""
+  and: ""
+  as: ""
+  assert: ""
+  async: ""
+  await: ""
+  break: ""
+  class: ""
+  continue: ""
+  def: ""
+  del: ""
+  elif: ""
+  else: ""
+  except: ""
+  finally: ""
+  for: ""
+  from: ""
+  global:  ""
+  if: ""
+  import: ""
+  in: ""
+  is: ""
+  lambda: ""
+  nonlocal: ""
+  not: ""
+  or: ""
+  pass: ""
+  raise: ""
+  return: ""
+  try: ""
+  while: ""
+  with: ""
+  yield: ""
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/bn.yml
+++ b/locale/bn.yml
@@ -1,0 +1,1917 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "bn"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "মিথ্যা"
+    # ✅  @SandipPalit
+  None: "কোনোটিই নয়"
+    # ✅  @SandipPalit
+  True: "সত্য"
+    # ✅  @SandipPalit
+  and: "এবং"
+    # ✅  @SandipPalit
+  as: "হিসাবে"
+    # ✅  @SandipPalit
+  assert: "দাবি করা"
+    # ❓  @SandipPalit
+  async: "অসমনিয়ত"
+    # ✅  @SandipPalit
+  await: "অপেক্ষা করা"
+    # ❓  @SandipPalit
+  break: "বিরতি"
+    # ✅  @SandipPalit
+  class: "বিভাগ"
+    # 🤔  @SandipPalit
+  continue: "বজায় রাখা"
+    # ❓  @SandipPalit
+  def: "নির্ধারণ"
+    # ✅  @SandipPalit
+  del: "মুছে ফেলা"
+    # ❓  @SandipPalit
+  elif: "অন্যথায় যদি"
+    # ✅  @SandipPalit
+  else: "অন্যথায়"
+    # ✅  @SandipPalit
+  except: "বাদে"
+    # ✅  @SandipPalit
+  finally: "অবশেষে"
+    # ✅  @SandipPalit
+  for: "জন্য"
+    # ✅  @SandipPalit
+  from: "হইতে"
+    # ✅  @SandipPalit
+  global:  "বিশ্বব্যাপী"
+    # ✅  @SandipPalit
+  if: "যদি"
+    # ✅  @SandipPalit
+  import: "আমদানি"
+    # ✅  @SandipPalit
+  in: "মধ্যে"
+    # ✅  @SandipPalit
+  is: "হয়"
+    # ✅  @SandipPalit
+  lambda: "বেনামী"
+    # ❓  @SandipPalit
+  nonlocal: "অস্থানীয়"
+    # ✅  @SandipPalit
+  not: "নয়"
+    # ✅  @SandipPalit
+  or: "অথবা"
+    # ✅  @SandipPalit
+  pass: "ছাড়পত্র"
+    # ✅  @SandipPalit
+  raise: "সৃষ্টি করা"
+    # ❓  @SandipPalit
+  return: "প্রত্যাবর্তন"
+    # ✅  @SandipPalit
+  try: "চেষ্টা"
+    # ✅  @SandipPalit
+  while: "যখন"
+    # ✅  @SandipPalit
+  with: "সঙ্গে"
+    # ✅  @SandipPalit
+  yield: "ফলন করা"
+    # ❓  @SandipPalit
+
+# << Built-In Functions >>
+
+  abs: "নিরপেক্ষ মূল্য"
+    # ✅  @SandipPalit
+  all: "সমস্ত"
+    # ✅  @SandipPalit
+  any: "যেকোনো"
+    # ✅  @SandipPalit
+  ascii: "অ্যাসকি"
+    # ❓  @SandipPalit
+  bin: "বাইনারি উপস্থাপনা"
+    # 🤔  @SandipPalit
+  bool: "বুলিয়ান"
+    # ✅  @SandipPalit
+  breakpoint: "ব্রেকপয়েন্ট"
+    # ✅  @SandipPalit
+  bytearray: "প্রদত্ত বাইটের অ্যারে"
+    # ❓  @SandipPalit
+  bytes: "বাইট"
+    # ✅  @SandipPalit
+  callable: "কলযোগ্য"
+    # ✅  @SandipPalit
+  chr: "প্রতিনিধিত্বকারী অক্ষর"
+    # 🤔  @SandipPalit
+  classmethod: "ক্লাস পদ্ধতি"
+    # ❓  @SandipPalit
+  compile: "কম্পাইল"
+    # ✅  @SandipPalit
+  complex: "জটিল"
+    # ✅  @SandipPalit
+  delattr: "বৈশিষ্ট্য মুছে ফেলুন"
+    # 🤔  @SandipPalit
+  dict: "অভিধান"
+    # ✅  @SandipPalit
+  dir: "সমস্ত বৈশিষ্ট্য এবং পদ্ধতি"
+    # ❓  @SandipPalit
+  divmod: "ভাগফল এবং তাদের বিভাগের অবশিষ্টাংশে"
+    # 🤔  @SandipPalit
+  enumerate: "গোনা"
+    # ✅  @SandipPalit
+  eval: "মূল্যায়ন"
+    # ✅  @SandipPalit
+  exec: "করণ"
+    # ✅  @SandipPalit
+  filter: "ফিল্টার"
+    # ✅  @SandipPalit
+  float: "ফ্লোট"
+    # ✅  @SandipPalit
+  format: "পদ্ধতি"
+    # ✅  @SandipPalit
+  frozenset: "তাদের অপরিবর্তনীয় করে তোলে"
+    # 🤔  @SandipPalit
+  getattr: "মান ফেরত দিন"
+    # ❓  @SandipPalit
+  globals: "বিশ্বব্যাপী"
+    # ✅  @SandipPalit
+  hasattr: "যদি বস্তুর বৈশিষ্ট্য থাকে"
+    # ❓  @SandipPalit
+  hash: "হ্যাশ"
+    # ✅  @SandipPalit
+  help: "সাহায্য"
+    # ✅  @SandipPalit
+  hex: "হেক্স"
+    # ✅  @SandipPalit
+  id: "আইডি"
+    # ✅  @SandipPalit
+  input: "ইনপুট"
+    # ✅  @SandipPalit
+  int: "পূর্ণসংখ্যা"
+    # ❓  @SandipPalit
+  isinstance: "যদি নির্দিষ্ট প্রকার"
+    # 🤔  @SandipPalit
+  issubclass: "যদি সাবক্লাস"
+    # ❓  @SandipPalit
+  iter: "পুনরাবৃত্তি"
+    # ✅  @SandipPalit
+  len: "দৈর্ঘ্য"
+    # ✅  @SandipPalit
+  list: "তালিকা"
+    # ✅  @SandipPalit
+  locals: "স্থানীয়দের"
+    # ✅  @SandipPalit
+  map: "মানচিত্র"
+    # ✅  @SandipPalit
+  max: "সর্বোচ্চ"
+    # ✅  @SandipPalit
+  memoryview: "মেমরিভিউ"
+    # ❓  @SandipPalit
+  min: "ন্যূনতম"
+    # ✅  @SandipPalit
+  next: "পরবর্তী"
+    # ✅  @SandipPalit
+  object: "বস্তু"
+    # ❓  @SandipPalit
+  oct: "অক্টাল মান"
+    # ✅  @SandipPalit
+  open: "খোলা"
+    # ✅  @SandipPalit
+  ord: "ইউনিকোড কোড"
+    # ❓  @SandipPalit
+  pow: "গুণ"
+    # ❓  @SandipPalit
+  print: "ছাপ"
+    # ✅  @SandipPalit
+  property: "বৈশিষ্ট্য"
+    # ✅  @SandipPalit
+  range: "পরিসীমা"
+    # ✅  @SandipPalit
+  repr: "স্ট্রিং প্রতিনিধিত্ব"
+    # ❓  @SandipPalit
+  reversed: "বিপরীত"
+    # ✅  @SandipPalit
+  round: "সুসম্পন্ন করা"
+    # ❓  @SandipPalit
+  set: "সেট"
+    # ✅  @SandipPalit
+  setattr: "বৈশিষ্ট্য সেট করে"
+    # 🤔  @SandipPalit
+  slice: "টুকরা"
+    # ✅  @SandipPalit
+  sorted: "সাজানো"
+    # ✅  @SandipPalit
+  staticmethod: "স্ট্যাটিক পদ্ধতি"
+    # ❓  @SandipPalit
+  str: "স্ট্রিং"
+    # ✅  @SandipPalit
+  sum: "যোগফল"
+    # ✅  @SandipPalit
+  super: "সুপার"
+    # ✅  @SandipPalit
+  tuple: "টুপল"
+    # ❓  @SandipPalit
+  type: "প্রকার"
+    # ✅  @SandipPalit
+  vars: "যার"
+    # ❓  @SandipPalit
+  zip: "জিপ"
+    # ✅  @SandipPalit
+  __import__: "__আমদানি__"
+    # ✅  @SandipPalit
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/cy.yml
+++ b/locale/cy.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "cy"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "ffug"
+  None: "Dim"
+  True: "Gwir"
+  and: "a"
+  as: "fel"
+  assert: "haeru"
+  async: "async"
+  await: "aros"
+  break: "egwyl"
+  class: "dosbarth"
+  continue: "parhau"
+  def: "def"
+  del: "del"
+  elif: "elif"
+  else: "arall"
+  except: "except"
+  finally: "o'r diwedd"
+  for: "am"
+  from: "o"
+  global:  "cynnyrch"
+  if: "os"
+  import: "cynnyrch"
+  in: "yn"
+  is: "yn"
+  lambda: "lambda"
+  nonlocal: "nonlocal"
+  not: "ddim"
+  or: "neu"
+  pass: "pasio"
+  raise: "codi"
+  return: "cynnyrch"
+  try: "thrio"
+  while: "tra"
+  with: "gyda"
+  yield: "cynnyrch"
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/da.yml
+++ b/locale/da.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "da"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: ""
+  None: ""
+  True: ""
+  and: ""
+  as: ""
+  assert: ""
+  async: ""
+  await: ""
+  break: ""
+  class: ""
+  continue: ""
+  def: ""
+  del: ""
+  elif: ""
+  else: ""
+  except: ""
+  finally: ""
+  for: ""
+  from: ""
+  global:  ""
+  if: ""
+  import: ""
+  in: ""
+  is: ""
+  lambda: ""
+  nonlocal: ""
+  not: ""
+  or: ""
+  pass: ""
+  raise: ""
+  return: ""
+  try: ""
+  while: ""
+  with: ""
+  yield: ""
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/de.yaml
+++ b/locale/de.yaml
@@ -1,0 +1,2998 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "de"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "auto"
+  # ✅ @JohannaHillebrand
+double: "Kommazahl"
+  # ✅ @JohannaHillebrand
+int: "GanzeZahl"
+  # ✅ @JohannaHillebrand
+struct: "Struktur"
+  # ✅ @JohannaHillebrand
+break: "Abbruch"
+  # ✅ @JohannaHillebrand
+else: "ansonsten"
+  # ✅ @JohannaHillebrand
+long: ""
+  # 🤔 @JohannaHillebrand
+switch: "switch"
+  # ❓ @JohannaHillebrand there is not really a good alternative in German
+case: "Fall"
+  # ✅ @JohannaHillebrand
+enum: "enum"
+  # ✅ @JohannaHillebrand
+register: "Register"
+  # ✅ @JohannaHillebrand
+typedef: "TypDefinition"
+  # ✅ @JohannaHillebrand
+char: "Zeichen"
+  # ✅ @JohannaHillebrand
+extern: "extern"
+  # ✅ @JohannaHillebrand
+return: "Rückgabe"
+  # ✅ @JohannaHillebrand
+union: ""
+  # 🤔 @JohannaHillebrand
+const: "Konstante"
+  # ✅ @JohannaHillebrand
+float: "Fließkommazahl"
+  # ✅ @JohannaHillebrand
+short: ""
+  # 🤔 @JohannaHillebrand
+unsigned: "vorzeichenlos"
+  # ✅ @JohannaHillebrand
+continue: "fahreFort"
+  # ✅ @JohannaHillebrand
+for: "für"
+  # ✅ @JohannaHillebrand
+signed: "vorzeichenbehaftet"
+  # ✅ @JohannaHillebrand
+void: "stumm"
+  # ❓ @JohannaHillebrand maybe
+default: "default"
+  # ✅ @JohannaHillebrand
+goto: "wechselZu"
+  # ✅ @JohannaHillebrand
+sizeof: "größeVon"
+  # ✅ @JohannaHillebrand
+volatile: ""
+  # 🤔 @JohannaHillebrand
+do: "tue"
+  # ✅ @JohannaHillebrand
+if: "wenn"
+  # ✅ @JohannaHillebrand
+static: "statisch"
+  # ✅ @JohannaHillebrand
+while: "solange"
+  # ✅ @JohannaHillebrand
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: "abstrakt"
+  # ✅ @JohannaHillebrand
+continue: "fahreFort"
+  # ✅ @JohannaHillebrand
+for: "für"
+  # ✅ @JohannaHillebrand
+new: "neu"
+  # ✅ @JohannaHillebrand
+switch: "switch"
+  # ✅ @JohannaHillebrand
+assert: "vergleiche"
+  # ✅ @JohannaHillebrand
+default: "default"
+  # ✅ @JohannaHillebrand
+goto: "geheZu"
+  # ✅ @JohannaHillebrand
+package: "Paket"
+  # ✅ @JohannaHillebrand
+synchronized: "synchronisiert"
+  # ✅ @JohannaHillebrand
+boolean: "Wahrheitswert"
+  # ✅ @JohannaHillebrand
+do: "tue"
+  # ✅ @JohannaHillebrand
+if: "wenn"
+  # ✅ @JohannaHillebrand
+private: "privat"
+  # ✅ @JohannaHillebrand
+this: "dieses"
+  # ✅ @JohannaHillebrand
+break: "Abbruch"
+  # ✅ @JohannaHillebrand
+double: "Kommazahl"
+  # ✅ @JohannaHillebrand
+implements: "implementiert"
+  # ✅ @JohannaHillebrand
+protected: "geschützt"
+  # ✅ @JohannaHillebrand
+throw: "werfe"
+  # ✅ @JohannaHillebrand
+byte: "Byte"
+  # ✅ @JohannaHillebrand
+else: "dann"
+  # ✅ @JohannaHillebrand
+import: "importiere"
+  # ✅ @JohannaHillebrand
+public: "öffentlich"
+  # ✅ @JohannaHillebrand
+throws: "werfe"
+  # ✅ @JohannaHillebrand
+case: "Fall"
+  # ✅ @JohannaHillebrand
+enum: "enum"
+  # ✅ @JohannaHillebrand
+instanceof: "instanzVon"
+  # ✅ @JohannaHillebrand
+return: "gebeZurück"
+  # ✅ @JohannaHillebrand
+transient: ""
+  # 🤔 @JohannaHillebrand
+catch: "fange"
+  # ✅ @JohannaHillebrand
+extends: "erweitert"
+  # ✅ @JohannaHillebrand
+int: "Ganzzahl"
+  # ✅ @JohannaHillebrand
+short: ""
+  # 🤔 @JohannaHillebrand
+try: "versuche"
+  # ✅ @JohannaHillebrand
+char: "Zeichen"
+  # ✅ @JohannaHillebrand
+final: "final"
+  # ✅ @JohannaHillebrand
+interface: "Interface"
+  # ✅ @JohannaHillebrand
+static: "statisch"
+  # ✅ @JohannaHillebrand
+void: "stumm"
+  # ✅ @JohannaHillebrand
+class: "Klasse"
+  # ✅ @JohannaHillebrand
+finally: "schlussendlich"
+  # ✅ @JohannaHillebrand
+long: ""
+  # 🤔 @JohannaHillebrand
+strictfp: ""
+  # 🤔 @JohannaHillebrand
+volatile: ""
+  # 🤔 @JohannaHillebrand
+const: "Konstante"
+  # ✅ @JohannaHillebrand
+float: "Fließkommazahl"
+  # ✅ @JohannaHillebrand
+native: "nativ"
+  # ✅ @JohannaHillebrand
+super: "super"
+  # ✅ @JohannaHillebrand
+while: "solange"
+  # ✅ @JohannaHillebrand
+_: ""
+  # 🤔 @JohannaHillebrand _(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: "argumente"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+await: "erwarte"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand "warteAuf"
+break: "bruch"
+  # ✅ @ZeroOne010101
+  # ❓ @LoLei "brich" Imperative of brechen, instead of noun Bruch
+  # ❓ @JohannaHillebrand "abbruch"
+case: "fall"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+catch: "fange"
+  # ❓ @ZeroOne010101 not sure
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand "fangeAuf"
+class: "klasse"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+const: "konstante"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+continue: "fortfahren"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand "fahreFort"
+debugger: "debugger"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+default: "default"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+delete: "lösche"
+  # ✅ @ZeroOne010101
+  # ❓ @LoLei "löschen" Imperative
+  # ✅ @JohannaHillebrand
+do: "tue"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+else: "sonst"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+enum: "enum"
+  # 🤔 @ZeroOne010101 no idea
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+eval: "evaluieren"
+  # ✅ @ZeroOne010101
+  # ❓ @LoLei "evaluiere" Imperative
+  # ✅ @JohannaHillebrand
+export: "exportieren"
+  # ✅ @ZeroOne010101
+  # ❓ @LoLei "exportiere" Imperative
+  # ✅ @JohannaHillebrand
+extends: "erweitert"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+false: "falsch"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+finally: "endlich"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand "schlussendlich"
+for: "für"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+from: "von"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+function: "funktion"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+# if:
+if: "wenn"
+  # ✅ @ZeroOne010101
+  # ❓ @LoLei If -> "falls" (It might happen), When -> Wenn (It will happen)
+  # ✅ @JohannaHillebrand "falls"
+implements: "implementiert"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+import: "importiere"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+in: "in"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+instanceof: "instanzvon"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+interface: "interface"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+let: "lasse"
+  # ✅ @ZeroOne010101 not sure
+  # ❓ @LoLei "sei" Mathematical notation e.g. let x be 5 -> Sei x 5
+  # ✅ @JohannaHillebrand
+new: "new"
+  # ✅ @ZeroOne010101
+  # ❓ @LoLei "neu"
+  # ✅ @JohannaHillebrand
+null: "null"
+  # 🤔 @ZeroOne010101 no idea
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+package: "paket"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+private: "privat"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+protected: "geschützt"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+public: "öffentlich"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+return: "return"
+  # ❓ @ZeroOne010101 rückgabe?
+  # ❓ @LoLei "gib"
+  # ❓ @JohannaHillebrand "gib"
+static: "statisch"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+super: "super"
+  # ❓ @ZeroOne010101 über?
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+switch: "schalter"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand works but weird
+this: "dies"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+throw: "throw"
+  # 🤔 @ZeroOne010101 no idea
+  # ❓ @LoLei "werfe"
+  # ❓ @JohannaHillebrand "werfe"
+true: "wahr"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+try: "versuche"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+typeof: "typvon"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+var: "var"
+  # 🤔 @ZeroOne010101 no idea
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+void: "void"
+  # 🤔 @ZeroOne010101 no idea
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand "stumm" maybe?
+while: "während"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ❓ @JohannaHillebrand "solange"
+with: "mit"
+  # ✅ @ZeroOne010101
+  # 👀 @LoLei
+  # ✅ @JohannaHillebrand
+yield: "yield" #✅
+  # ❓ @ZeroOne010101 ausgabe? ausbeute?
+  # ❓ @LoLei "liefere"
+  # ❓ @JohannaHillebrand "liefere"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+#
+# translation syntax:
+#
+# # xxx? -> alternative word that may or may not fit better
+# # no idea -> cant think of a german equivalent
+# # works but weird -> its translated and makes sense, but sounds weird to me ...
+# ... needs second opinion on wether to translate or keep english
+
+# @nausicaea General comment to German translations; due to its grammatical structure, German tends to use more than one word where only one is sufficient in English. This means that many keywords are not easily translatable.
+
+  False: "Falsch"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  None: "Nichts"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  True: "Wahr"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  and: "und"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  as: "als"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  assert: "assert"
+    # ❓ @ZeroOne010101 "stelle_fest"? "behaupte"?
+    # ❓ @LoLei "behaupte"
+    # ❓ @nausicaea "fordere"
+    # 👀 @otherpaco
+    # 👀 @JohannaHillebrand
+    # ❓ @merelyAnna "bestätige" or "versichere" might fit better
+    # ❓ @diana48 "bestätige"
+    # ✅ @twille00
+    # ❓ @alxnull (agree with "versichere")
+  async: "asynchron"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  await: "erwarte"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei (if spaces are possible, prefer "warte ab")
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ❓ @JohannaHillebrand "warte auf"
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  break: "bruch"
+    # ✅ @ZeroOne010101
+    # ❓ @LoLei "brich" Imperative instead of noun
+    # ✅ @nausicaea "brich"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "Abbruch"
+    # ❓ @merelyAnna "brich ab" fits better; just "brich" rather means "to fracture something"
+    # ❓ @diana48 "brich ab"
+    # ❓ @twille00 "brich ab"
+    # ❓ @alxnull "brich ab"
+  class: "klasse"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ❓ @otherpaco Klasse is a noun
+    # ✅ @JohannaHillebrand Klasse is a noun # needs a capital "K"
+    # ✅ @merelyAnna I second @JohannaHillebrand, the "K" needs to be uppercase
+    # ✅ @diana48 I agree with @JohannaHillebrand "Klasse"
+    # ✅ @twille00
+    # ✅ @alxnull I agree with @JohannaHillebrand "Klasse"
+  continue: "fortfahren"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "überspringe" (imperative and the semantic meaning is clearer)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand works but weird
+    # ❓ @merelyAnna I second "überspringe"
+    # ✅ @diana48
+    # ✅ @twille00
+    # ❓ @alxnull "überspringe"
+  def: "def"
+    # ✅ @ZeroOne010101 short | definiere?
+    # 👀 @LoLei
+    # ✅ @nausicaea "definiere" (prefer long form)
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # 🤔 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  del: "lösche"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00
+    # ✅ @alxnull
+  elif: "sonstwenn"
+    # ✅ @ZeroOne010101
+    # ❓ @LoLei "sonstfalls"  If -> falls, when -> wenn
+    # ❓ @nausicaea "andernfalls"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "ansonsten"
+    # ❓ @merelyAnna "sonstfalls"
+    # ✅ @diana48
+    # ✅ @twille00
+    # ❓ @alxnull "sonstfalls" sounds weird, would prefer "andernfalls"
+  else: "sonst"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  except: "außer"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  finally: "endlich"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "schlußendlich"
+    # ❓ @otherpaco "abschließend"
+    # ❓ @JohannaHillebrand "schlußendlich"
+    # ❓ @merelyAnna I second "schlußendlich"
+    # ❓ @diana48 "schlußendlich"
+    # ✅ @twille00
+    # ❓ @alxnull "schlußendlich"
+  for: "für"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00
+    # ✅ @alxnull
+  from: "von"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "aus" (in the semantic context of python, this represents the meaning more clearly)
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna I second "aus"
+    # ❓ @diana48 I agree with @nausicaea
+    # ✅ @twille00
+    # ❓ @alxnull "aus"
+  global: "global"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  if: "wenn"
+    # ✅ @ZeroOne010101
+    # ❓ @LoLei "falls" If -> falls, when -> wenn
+    # ✅ @nausicaea "falls"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "falls"
+    # ❓ @merelyAnna "falls"
+    # ❓ @diana48 "falls"
+    # ✅ @twille00
+    # ❓ @alxnull "falls"
+  import: "importiere"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "verwende"
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  in: "in"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  is: "ist"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  lambda: "lambda"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna It's a noun, so "Lambda"
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull "Lambda"
+  nonlocal: "unlogisch"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "unlogisch" is definitely wrong. "nichtlokal"  is the appropriate translation
+    # ❓ @otherpaco "nonlokal"
+    # ❓ @JohannaHillebrand "nichtlokal"
+    # 🤔 @merelyAnna
+    # ❓ @diana48 "nichtlokal"
+    # 👀 @twille00
+    # ❓ @alxnull  agree with @nausicaea
+  not: "nicht"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  or: "oder"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  pass: "besteht"
+    # ❓ @ZeroOne010101 bestanden?
+    # ❓ @LoLei "weiter" pass in python means to execute a line of code that does nothing
+    # ❓ @nausicaea "weiter"
+    # ❓ @otherpaco "weiter"
+    # ❓ @JohannaHillebrand "weiter"
+    # ❓ @merelyAnna "weiter"
+    # ❓ @diana48 "weiter"
+    # ❓ @twille00 "weiter"
+    # ❓ @alxnull "weiter"
+  raise: "raise"
+    # ❓ @ZeroOne010101 erheben?
+    # ❓ @LoLei "erhebe"
+    # ❓ @nausicaea (I'm not happy with this, because one cannot use "erhebe eine Ausnahme", i.e. raise an exception, in German)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "auslösen"
+    # 👀 @merelyAnna
+    # ❓ @diana48 "löse aus"
+    # ❓ @twille00 "löse aus"
+    # ❓ @alxnull not a direct translation, but "werfe" might be a more suitable translation, i.e. "werfe eine Ausnahme"
+  return: "return"
+    # ❓ @ZeroOne010101 rückgabe?
+    # ❓ @LoLei "gib"
+    # ❓ @nausicaea (if spaces are possible, prefer "gib zurück")
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "gib zurück"
+    # 👀 @merelyAnna
+    # ❓ @diana48 "gib zurück"
+    # ❓ @twille00
+    # ❓ @alxnull "gib"
+  try: "versuche"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  while: "während"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00
+    # ❓ @alxnull maybe "solange" would also fit
+  with: "mit"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00
+    # ✅ @alxnull
+  yield: "yield"
+    # ❓ @ZeroOne010101 ausgabe? ausbeute?
+    # ❓ @LoLei "liefere"
+    # ❓ @nausicaea (if spaces are possible, prefer "gib ab". This would completement the translation of return)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "liefere"
+    # ❓ @merelyAnna I second @nausicaea
+    # ❓ @diana48 I agree @nausicaea
+    # ❓ @twille00
+    # ❓ @alxnull agree with @nausicaea
+
+# << Built-In Functions >>
+
+  abs: "abs"
+    # ❓ @ZeroOne010101 absoluter wert?
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "absolut"
+    # ✅ @merelyAnna
+    # ❓ @diana48 "absolut"
+    # ❓ @twille00 "absolut"
+    # ✅ @alxnull
+  all: "alle"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  any: "eines"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ❓ @otherpaco "beliebig"
+    # ❓ @JohannaHillebrand "beliebig"
+    # ❓ @merelyAnna I second "beliebig"
+    # ❓ @diana48 "beliebig"
+    # ❓ @twille00 "beliebig"
+    # ❓ @alxnull "beliebig"
+  ascii: "ascii"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  bin: "bin"
+    # ❓ @ZeroOne010101 binär?
+    # 👀 @LoLei
+    # ❓ @nausicaea prefer "binär"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "binär"
+    # ❓ @merelyAnna I second "binär"
+    # ❓ @diana48 "binär"
+    # ❓ @twille00 "binär"
+    # ❓ @alxnull "binär"
+  bool: "bool"
+    # ❓ @ZeroOne010101 warheitswert?
+    # 👀 @LoLei
+    # ✅ @nausicaea (because bool refers to the last name of George Bool, I think the original value is appropriate)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "warheitswert"
+    # ❓ @merelyAnna "warheitswert"
+    # ❓ @diana48 "warheitswert"
+    # ❓ @twille00 "warheitswert"
+    # ✅ @alxnull
+  breakpoint: "bruchpunkt"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ❓ @otherpaco "Bruchpunkt"
+    # ❓ @JohannaHillebrand "Abbruchpunkt"
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00 "Abbruchpunkt"
+    # ✅ @alxnull
+  bytearray: "bytearray"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "byteabfolge"
+    # ✅ @otherpaco "Bytearray"
+    # ✅ @JohannaHillebrand "Bytearray"
+    # ✅ @merelyAnna "Bytearray"
+    # ✅ @diana48 "Bytearray"
+    # ✅ @twille00 "Bytearray"
+    # ❓ @alxnull "bytefolge"
+  bytes: "bytes"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ❓ @otherpaco "Bytes"
+    # ✅ @JohannaHillebrand "Bytes"
+    # ✅ @merelyAnna
+    # ✅ @diana48 "Bytes"
+    # ✅ @twille00 "Bytes"
+    # ✅ @alxnull "Bytes"
+  callable: "rufbar"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "aufrufbar"
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna I second "aufrufbar"
+    # ❓ @diana48 "aufrufbar"
+    # ❓ @twille00 "aufrufbar"
+    # ❓ @alxnull "aufrufbar"
+  chr: "chr"
+    # ❓ @ZeroOne010101 zeichen?
+    # 👀 @LoLei
+    # ❓ @nausicaea prefer "zeichen"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "zeichen"
+    # ❓ @merelyAnna "Buchstabe" oder "Zeichen"
+    # ❓ @diana48 "zeichen"
+    # 👀 @twille00
+    # ❓ @alxnull "Zeichen"
+  classmethod: "klassenmethode"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ❓ @otherpaco "Klassenmethode"
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ❓ @diana48 "Klassenmethode"
+    # ❓ @twille00 "Klassenmethode"
+    # ❓ @alxnull "Klassenmethode"
+  compile: "compiliere"
+    # ✅ @ZeroOne010101
+    # ❓ @LoLei "kompiliere" German spelling
+    # ❓ @nausicaea "kompiliere"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "kompiliere"
+    # ❓ @merelyAnna "kompiliere"
+    # ❓ @diana48 "kompiliere"
+    # ✅ @twille00
+    # ❓ @alxnull "kompiliere" German spelling
+  complex: "komplex"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  delattr: ""
+    # 🤔 @ZeroOne010101 entfattr?
+    # 👀 @LoLei
+    # ❓ @nausicaea I like "entfattr"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "löscheAttribut"
+    # ❓ @merelyAnna "lösche Attribut", shortened to "löeschattr" maybe
+    # ❓ @diana48 "lösche Attribut"
+    # 👀 @twille00
+    # ❓ @alxnull "entfattr"
+  dict: "dict"
+    # ❓ @ZeroOne010101 "wörterbuch"?
+    # 👀 @LoLei
+    # ❓ @nausicaea aufschlüßelung / schlüßeltabelle (A dict here, does not refer to a table of words, but a table of key-value pairs)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "wörterbuch"
+    # ❓ @merelyAnna The German equivalent for dictionary would probably be "assoziative Liste", so maybe shortened to "assozListe"; "Wörterbuch" a literal translation
+    # ❓ @diana48 "assoziative Liste"
+    # ✅ @twille00
+    # 🤔 @alxnull
+  dir: "ver"
+    # ❓ @ZeroOne010101  verzeichnis?
+    # 👀 @LoLei
+    # ❓ @nausicaea "verz" (based on German abbreviation rules, the latter is correct)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "Verzeichnis"
+    # ❓ @merelyAnna I second "Verzeichnis"
+    # ❓ @diana48 "Verzeichnis"
+    # ❓ @twille00 "Verzeichnis"
+    # ❓ @alxnull "Verzeichnis"
+  divmod: "divmod"
+    # 🤔 @ZeroOne010101 no idea, division(en) == division(de) so...
+    # 👀 @LoLei
+    # ✅ @nausicaea (I agree with using "divmod", because both division and modulo are the same in German)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "modulo"
+    # 🤔 @merelyAnna
+    # ❓ @diana48 "Division mit Rest"
+    # ❓ @twille00 "Division mit Rest"
+    # ✅ @alxnull
+  enumerate: "aufzählen"
+    # ❓ @ZeroOne010101 "zähle_auf"?
+    # 👀 @LoLei
+    # ❓ @nausicaea "nummeriere"
+    # ✅ @otherpaco
+    # ❓ @JohannaHillebrand "zähle_auf"
+    # ❓ @merelyAnna "zähle_auf"
+    # ❓ @diana48 "zähle_auf"
+    # ❓ @twille00
+    # 🤔 @alxnull
+  eval: "evaluiere"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea verarbeite / berechne
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00 verarbeite / berechne
+    # ✅ @alxnull
+  exec: "ausführen"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea (if spaces are possible, use "führe aus" or "rufe auf")
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  filter: "filter"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea filtriere
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ❓ @alxnull "filtriere"
+  float: "float"
+    # 🤔 @ZeroOne010101 no idea
+    # ❓ @LoLei "gleitkomma" # Gleitkomma or Fließkomma is floating point
+    # ❓ @nausicaea prefer "fließkomma" because it's more widely used
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "Fließkomma"
+    # ❓ @merelyAnna "Fließkomma"
+    # ❓ @diana48 "Fließkomma"
+    # 👀 @twille00
+    # ❓ @alxnull "Fließkomma"
+  format: "format"
+    # ❓ @ZeroOne010101 -> noun | formatiere -> imperativ
+    # 👀 @LoLei
+    # ❓ @nausicaea prefer "formatiere" because semantically, it's a function
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "formatiere"
+    # ❓ @merelyAnna I agree "formatiere"
+    # ❓ @diana48 "formatiere"
+    # 👀 @twille00
+    # ❓ @alxnull "formatiere"
+  frozenset: "frozenset"
+    # ❓ @ZeroOne010101 gefrorenes set?
+    # 👀 @LoLei
+    # ❓ @nausicaea festmenge (Frozenset refers to a set of unique values that is not modifiable after its creation)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand works but weird
+    # 🤔 @merelyAnna
+    # 🤔 @diana48
+    # 👀 @twille00
+    # 🤔 @alxnull
+  getattr: "getattr"
+    # ❓ @ZeroOne010101 holeattribute?
+    # 👀 @LoLei
+    # ❓ @nausicaea "nimmattr"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "holeAttribute"
+    # ❓ @merelyAnna I second "holeattr"
+    # ❓ @diana48 "holeattr"
+    # 👀 @twille00
+    # ❓ @alxnull "holeattr"
+  globals: "globale"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea (alternatively, "globalvar" for "globale Variable")
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  hasattr: "hatattr"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "hatAttribut"
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  hash: "hash"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea schlüssel / streuwert
+    # ✅ @otherpaco
+    # ❓ @JohannaHillebrand "Streuwert"
+    # 🤔 @merelyAnna "Streuwert" is the best/the most literal translation, but I think "hash" works just fine
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  help: "hilfe"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  hex: "hex"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna "hexadezimalzahl"
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  id: "id"
+    # 🤔 @ZeroOne010101 no idea, probably same
+    # 👀 @LoLei
+    # ✅ @nausicaea (or "identität")
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  input: "eingabe"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ❓ @otherpaco "Eingabe"
+    # ❓ @JohannaHillebrand "Eingabe"
+    # ✅ @merelyAnna
+    # ✅ @diana48 "Eingabe"
+    # 👀 @twille00
+    # ✅ @alxnull "Eingabe"
+  int: "int"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "ganzzahl"
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  isinstance: "istinstanz"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  issubclass: "istsubklasse"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  iter: "iter"
+    # 🤔 @ZeroOne010101 no idea
+    # ✅ @LoLei Iterator same in German
+    # ✅ @nausicaea
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  len: "länge"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco "Länge"
+    # ✅ @JohannaHillebrand "Länge"
+    # ✅ @merelyAnna
+    # ✅ @diana48 "Länge"
+    # 👀 @twille00
+    # ✅ @alxnull "Länge"
+  list: "liste"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco "Liste"
+    # ✅ @JohannaHillebrand "Liste"
+    # ✅ @merelyAnna
+    # ✅ @diana48 "Liste"
+    # 👀 @twille00
+    # ✅ @alxnull "Liste"
+  locals: "locale"
+    # ✅ @ZeroOne010101 works but weird
+    # 👀 @LoLei
+    # ❓ @nausicaea lokale / lokalvar (analogous to globals)
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand lokale or maybe lokaleVariable
+    # 🤔 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ❓ @alxnull "lokale"
+  map: "map"
+    # 🤔 @ZeroOne010101 no idea
+    # ❓ @LoLei "karte"
+    # ❓ @nausicaea zuweisung
+    # 👀 @otherpaco
+    # 🤔 @JohannaHillebrand no idea
+    # 🤔 @merelyAnna "Karte" doesn't fit, depending on the context it means menu, or ticket, or chart, ...
+    # ✅ @diana48
+    # 👀 @twille00
+    # 🤔 @alxnull no idea, maybe "Abbildung"
+  max: "max"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  memoryview: "memoryview"
+    # ❓ @ZeroOne010101 "speichersicht" ?
+    # ❓ @LoLei "speicheransicht"
+    # ❓ @nausicaea "speicheransicht"
+    # ❓ @otherpaco "Speicheransicht"
+    # ❓ @JohannaHillebrand "Speicheransicht"
+    # ❓ @merelyAnna "speicheransicht"
+    # ❓ @diana48 "Speicheransicht"
+    # 👀 @twille00
+    # ❓ @alxnull "Speicheransicht"
+  min: "min"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  next: "weiter"
+    # ✅ @ZeroOne010101
+    # ❓ @LoLei "nächstes" More literal translation
+    # ✅ @nausicaea
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna "nächstfolgend"
+    # ✅ @diana48
+    # 👀 @twille00
+    # ❓ @alxnull "nächstes"
+  object: "objekt"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull "Objekt"
+  oct: "oct"
+    # 🤔 @ZeroOne010101 no idea
+    # 👀 @LoLei
+    # ❓ @nausicaea okt / oktal / oktalzahl
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand no idea
+    # ❓ @merelyAnna "oktalzahl
+    # ✅ @diana48
+    # 👀 @twille00
+    # ❓ @alxnull oktal
+  open: "öffne"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  ord: "ord"
+    # 🤔 @ZeroOne010101 no idea
+    # 👀 @LoLei
+    # ❓ @nausicaea ord / ordnungszahl
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # 🤔 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  pow: "potenz"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  print: "drucke"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea (if spaces are allowed, "gib aus")
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # 👀 @twille00
+    # ✅ @alxnull
+  property: "eigenschaft"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco "Eigenschaft"
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull "Eigenschaft"
+  range: "reichweite"
+    # ❓ @ZeroOne010101 "Bereich"
+    # ❓ @LoLei "bereich" Better fitting in context
+    # ❓ @nausicaea "bereich" (alternatively, "intervall")
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "bereich"
+    # ❓ @merelyAnna "bereich"
+    # ❓ @diana48 "bereich"
+    # ✅ @twille00
+    # ❓ @alxnull "Bereich"
+  repr: "repr"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # 🤔 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  reversed: "umgekehrt"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  round: "runde"
+    # ❓ @ZeroOne010101 +n ?
+    # ✅ @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ❓ @twille00
+    # ✅ @alxnull
+  set: "setze"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  setattr: "setzeattr"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  slice: "scheibe"
+    # ✅ @ZeroOne010101 weird but works
+    # ❓ @LoLei "schnitt" slice in this case is not necessarily a round plate, which "scheibe" implies
+    # ❓ @nausicaea abschnitt / ausschnitt
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna "Scheibe" fits (eine Scheibe Brot = a slice of bread) or "Stück" maybe
+    # ✅ @diana48
+    # ❓ @twille00 "Stück"
+    # ❓ @alxnull "schnitt"
+  sorted: "sortiert"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  staticmethod: "statischemethode"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ❓ @JohannaHillebrand should be "statischeMethode", because its two words and therefore camelcase is easier to read
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ❓ @alxnull agree with @JohannaHillebrand
+  str: "str"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "text"
+    # ❓ @otherpaco "text"
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna "text"
+    # ❓ @diana48 "text"
+    # ❓ @twille00 "text"
+    # ✅ @alxnull
+  sum: "sum"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea "summe"
+    # ❓ @otherpaco "summe"
+    # ✅ @JohannaHillebrand
+    # ❓ @merelyAnna "summe"
+    # ❓ @diana48 "summe"
+    # ❓ @twille00 "summe"
+    # ❓ @alxnull "summe"
+  super: "über"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea (I don't really see a better translation than "super", given the keyword refers to the base class)
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # ✅ @merelyAnna I second "über"
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+  tuple: "tuple"
+    # ❓ @ZeroOne010101 no idea
+    # 👀 @LoLei
+    # ❓ @nausicaea "tupel"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "Tupel"
+    # ❓ @merelyAnna "Tupel"
+    # ❓ @diana48 "Tupel"
+    # ❓ @twille00 "Tupel"
+    # ❓ @alxnull "Tupel"
+  type: "typ"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ✅ @nausicaea
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand "Typ"
+    # ✅ @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull "Typ"
+  vars: "vars"
+    # ❓ @ZeroOne010101 variablen?
+    # 👀 @LoLei
+    # ❓ @nausicaea prefer "variablen"
+    # 👀 @otherpaco
+    # ❓ @JohannaHillebrand "Variablen"
+    # ❓ @merelyAnna I second "variablen"
+    # ❓ @diana48 "Variablen"
+    # ❓ @twille00 "Variablen"
+    # ❓ @alxnull "Variablen"
+  zip: "zip"
+    # 🤔 @ZeroOne010101 no idea
+    # 👀 @LoLei
+    # ❓ @nausicaea reißverschluss / paarbildung (maybe abbreviated as "paar")
+    # 👀 @otherpaco
+    # ✅ @JohannaHillebrand
+    # 🤔 @merelyAnna
+    # ✅ @diana48
+    # 🤔 @twille00 no idea
+    # 🤔 @alxnull
+  __import__: "__importiere__"
+    # ✅ @ZeroOne010101
+    # 👀 @LoLei
+    # ❓ @nausicaea __verwende__
+    # ✅ @otherpaco
+    # ✅ @JohannaHillebrand
+    # 👀 @merelyAnna
+    # ✅ @diana48
+    # ✅ @twille00
+    # ✅ @alxnull
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/el.yml
+++ b/locale/el.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "el"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "ΣΗΜΕΙΩΣΗ"
+  INFO: "ΠΛΗΡΟΦΟΡΙΕΣ"
+  IDEA: "ΙΔΕΑ"
+  DEBUG: "ΣΦΑΛΜΑΤΑ"
+  REMOVE: "ΑΦΑΙΡΕΣΕ"
+  OPTIMIZE: "ΒΕΛΤΙΣΤΟΠΟΙΗΣΕ"
+  REVIEW: "ΕΠΑΝΕΞΕΤΑΣΗ"
+  HACK: "ΧΑΚΑΡΕ"
+  UNDONE: "ΑΝΟΛΟΚΛΗΡΩΤΟ"
+  TODO: "ΝΑΚΑΝΩ"
+  REFACTOR: "ΑΝΑΔΟΜΗΣΗ"
+  DEPRECATED: "ΑΠΟΣΥΡΣΗ"
+  TASK: "ΑΠΟΣΤΟΛΗ"
+  CHGME: "" #?
+  NOTREACHED: "ΔΕΝΕΦΤΑΣΕ"
+  WTF: "" #?
+  BUG: "ΣΦΑΛΜΑ"
+  ERROR: "ΛΑΘΟΣ"
+  OMG: "ΩΘΜ" #Ω ΘΕΕ ΜΟΥ!
+  ERR: "ΛΑΘ"
+  OMFGRLY: "" #?
+  WARNING: "ΠΡΟΕΙΔΟΠΟΙΗΣΗ"
+  WARN: "ΠΡΟΕΙΔ"
+  BROKEN: "ΣΠΑΣΜΕΝΟ"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Ψευδής"
+  None: "Κενό"
+  True: "Αληθής"
+  and: "και"
+  as: "ως"
+  assert: "υποστήριξη"
+  async: "ασύγχ"
+  await: "αναμονή"
+  break: "θράυση" #"διακοπ΄ή"
+  class: "κλάση"
+  continue: "συνέχεια"
+  def: "ορισμός"
+  del: "διαγ"
+  elif: "αλλάν"
+  else: "αλλιώς"
+  except: "εκτός"
+  finally: "τελικά"
+  for: "για"
+  from: "από"
+  global:  "καθολικός"
+  if: "αν"
+  import: "εισαγωγή"
+  in: "εντός"
+  is: "είναι"
+  lambda: "λάμβδα"
+  nonlocal: "εξωτερικός"
+  not: "όχι"
+  or: "ή"
+  pass: "πέρασμα"
+  raise: "ύψωση"
+  return: "επιστροφή"
+  try: "δοκιμή"
+  while: "καθώς"
+  with: "με"
+  yield: "παραχώρηση" #"υποχώρηση"
+
+# << Built-In Functions >>
+
+  abs: "απόλ"
+  all: "όλα"
+  any: "όποιος"
+  ascii: "άσκιι"
+  bin: "δυαδ"
+  bool: "λογτιμή" # από "λογική τιμή"
+  breakpoint: "σημείοκαμπής"
+  bytearray: "ψηφιόλεξηπίνακας"
+  bytes: "ψηφιόλεξη"
+  callable: "κλητικός"
+  chr: "χαρ"
+  classmethod: "κλάσημέθοδος"
+  compile: "σύνθεση" #"κατάρτιση", "απάνθιση"
+  complex: "μιγαδικός"
+  delattr: "διαγχαρ"
+  dict: "λεξ"
+  dir: "ευρ" # ευρετήριο
+  divmod: "διάυπολ" #διά, υπόλοιπο
+  enumerate: "απαρίθμηση"
+  eval: "υπολ"
+  exec: "εκτελ"
+  filter: "φίλτρο"
+  float: "δεκαδ"
+  format: "φορμάτ"
+  frozenset: "παγωμένοσύνολο"
+  getattr: "λάβεχαρ"
+  globals: "καθολικά"
+  hasattr: "έχειχαρ"
+  hash: "κατατεμαχισμός"
+  help: "βοήθεια"
+  hex: "δεκαεξαδικός"
+  id: "ταυτότητα"
+  input: "καταχώρηση"
+  int: "ακερ"
+  isinstance: "είναιπερίπτωση"
+  issubclass: "υποκλαση"
+  iter: "επαν"
+  len: "μετρ" #μέτρημα
+  list: "λίστα"
+  locals: "εσωτερικά"
+  map: "αντιστοιχία"
+  max: "μαξ"
+  memoryview: "μνήμη"
+  min: "μιν"
+  next: "επόμενο"
+  object: "αντικείμενο"
+  oct: "οκτ"
+  open: "άνοιξε"
+  ord: "κωδ" #from "κωδικοποίηση"
+  pow: "δύναμη"
+  print: "τύπωσε"
+  property: "ιδιότητα"
+  range: "διάστημα"
+  repr: "αναπ" #from "αναπαράσταση"
+  reversed: "αντιστροφή"
+  round: "στρογγ" #στρογγυλοποίηση
+  set: "σύνολο"
+  setattr: "θέσεχαρ"
+  slice: "τεμάχισε"
+  sorted: "ταξινόμησε"
+  staticmethod: "στατικήμέθοδος"
+  str: "αλφ" #αλφαριθμητικό
+  sum: "άρθροισμα"
+  super: "σούπερ"
+  tuple: "πλειάδα"
+  type: "τύπος"
+  vars: "μεταβ" #"μεταβλητές"
+  zip: "ζιπ"
+  __import__: "__εισαγωγή__"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/es.yml
+++ b/locale/es.yml
@@ -1,0 +1,2651 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "es"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Falso"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  None: "Ninguno"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  True: "Verdadero"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  and: "Y"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  as: "como"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # 👀 @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  assert: "afirmar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ❓ @reegoram What about "asegurar"?
+    # ✅ @kararade I agree with "afirmar"
+    # ✅ @JJgar2725 I also agree with "afirmar"
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert I agree with "afirmar"
+  async: "asíncrono"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  await: "esperar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  break: "romper"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "interrumpir"
+    # ✅ @reegoram "interrumpir"
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf Also "romper"
+    # ✅ @begeistert Yes, it also could be "romper"
+  class: "clase"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  continue: "continuar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  def: "definir"
+    # ✅ @zoomstereo def it's a short for define, in the traslated version isn't shorted
+    # ✅ @asperduti
+    # ❓ @reegoram What about using "define" as imperative, because you're defining something?
+    # ✅ @kararade I agree with "define"
+    # ✅ @JJgar2725 I also agree with "define"
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  del: "eliminar"
+    # ✅ @zoomstereo same as def
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725 could be left as del, but eliminar is good as well
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert Also "borrar"
+  elif: "si no, si"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ❓ @reegoram  "si no, si" I added a comma here, it's something like, if this does not satisfy let's try this other
+    # ✅ @kararade I agree with the comment, it is better having the comma
+    # ✅ @JJgar2725 I agree that having the comma may be beneficial, but it might also be a bit too long (maybe something like no, si is fine, similar to else if)
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  else: "entonces"
+    # ✅ @zoomstereo in this context means "entonces" because "if else" is "si entonces"
+    # ✅ @asperduti "si no"
+    # ✅ @reegoram "si no"
+    # ✅ @kararade "si no"
+    # ✅ @JJgar2725 "si no"
+    # ✅ @aliciacisnerosm "si no"
+    # ✅ @iam-agf "si no"
+    # ✅ @begeistert "si no"
+  except: "excepto"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  finally: "finalmente"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  for: "por"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "para"
+    # ✅ @reegoram "para"
+    # ✅ @kararade "para"
+    # ✅ @JJgar2725 "para"
+    # ✅ @aliciacisnerosm "para"
+    # ✅ @iam-agf "para"
+    # ✅ @begeistert "para"
+  from: "desde"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  global:  "global"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  if: "si"
+    # ✅ @zoomstereo same in the else keyword, in this context means "si"
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  import: "importar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  in: "en"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  is: "es"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  lambda: "lambda"
+    # 🤔 @zoomstereo there isn't translation for this word to spanish,
+    # ❓ @asperduti "función anónima"
+    # 🤔 @reegoram What about using the same word?
+    # 🤔 @kararade I agree with the above comment, in this case is better to keep the same word "lambda"
+    # 🤔 @JJgar2725 I agree with keeping the word lamba, 'función anónima' may be a bit too much
+    # 🤔 @aliciacisnerosm I also agree with the second comment
+    # 🤔 @iam-agf The word should stay as lambda, since it's a greek word, and in Spanish is the same.
+    # 🤔 @begeistert I agree with using lambda
+  nonlocal: "no local"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  not: "no"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  or: "o"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  pass: "pasar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  raise: "subir"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "genera excepción"
+    # ❓ @reegoram "genera excepción"
+    # ❓ @kararade maybe just "generar" will be ok
+    # ❓ @JJgar2725 I agree with keeping generar
+    # ✅ @aliciacisnerosm
+    # ❓ @iam-agf In the Python documentation in Spanish is used "lanza" or "levanta"
+    # ✅ @begeistert
+  return: "retornar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram "regresa" Regresa sounds more natural for me than retorna
+    # ❓ @kararade I think that in this case "retorna" it is the better way to translate it, as we are talking that a function will run to then return a value, in spanish will be "la función se ejecuta y retorna un valor"
+    # ✅ @JJgar2725 I think "regresa" would be just fine
+    # ✅ @aliciacisnerosm
+    # ❓ @iam-agf The word "retorna" is accepted in the Spanish Python documentation
+    # ✅ @begeistert
+  try: "intentar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram "intenta" I also think of using this as imperative
+    # ✅ @kararade I agree with "intenta"
+    # ❓ @JJgar2725 maybe "tratar" would be better? intenta sounds okay too
+    # ✅ @aliciacisnerosm "intenta"
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  while: "mientras"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  with: "con"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  yield: "generador"
+    # ✅ @zoomstereo it isn't the direct translation, but it's more understandeable since yield returns a generator
+    # ❓ @asperduti "entregar" yield return a generator, insted of use "retornar", "entregar" can be more properly
+    # ✅ @reegoram "entregar"
+    # ✅ @kararade I agree with the comment, "entregar" it is better
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+# << Built-In Functions >>
+
+  abs: "absoluto"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "valor absoluto"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  all: "todos"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "todos iterables"
+    # ✅ @reegoram I think we can omite "iterable"
+    # ✅ @kararade I agree with "todos"
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  any: "cualquier"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "alguno iterable"
+    # ✅ @reegoram same here
+    # ✅ @kararade  I agree with "alguno"
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  ascii: "ascii"
+    # ✅ @zoomstereo does not have direct translation
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  bin: "binarios"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "binario"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  bool: "booleano"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  breakpoint: "punto de ruptura"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram "punto de interrupción" Punto de interrupción sounds more natural for me
+    # ✅ @kararade I agree with the comment
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  bytearray: "arreglo de byte"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # 🤔 @iam-agf The word "byte" should be in plural as "bytes"
+    # 🤔 @begeistert I agree with the comment above
+  bytes: "byte"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "bytes"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  callable: "llamable"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ❓ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ❓ @iam-agf It's more appropiate the word "invocable", and the Python documentation accepts it instead of the one here.
+    # ❓ @begeistert
+  chr: "caracter"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  classmethod: "metodo de la clase"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf "método de la clase"
+    # ✅ @begeistert
+  compile: "compilar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  complex: "complejo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  delattr: "eliminar atributo"
+    # ✅ @zoomstereo  from delete attribute
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  dict: "diccionario"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  dir: "directorio"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "atributos"
+    # ✅ @reegoram "atributos"
+    # ✅ @kararade "atributos"
+    # ✅ @JJgar2725  "atributos"
+    # ✅ @aliciacisnerosm  "atributos"
+    # ✅ @iam-agf  "atributos"
+    # ✅ @begeistert "atributos"
+  divmod: "mode de division"
+    # ✅ @zoomstereo not quite sure if it should be translated like this
+    # ❓ @asperduti "cociente y resto"
+    # ✅ @reegoram "cociente y resto"
+    # ✅ @kararade "cociente y resto"
+    # ✅ @JJgar2725 "cociente y resto"
+    # ✅ @aliciacisnerosm "cociente y resto"
+    # ✅ @iam-agf "cociente y resto"
+    # ✅ @begeistert "cociente y resto"
+  enumerate: "enumerado"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "enumerar"
+    # ✅ @reegoram "enumerar"
+    # ✅ @kararade "enumerar"
+    # ✅ @JJgar2725 "enumerar"
+    # ✅ @aliciacisnerosm "enumerar"
+    # ✅ @iam-agf "enumerar"
+    # ✅ @begeistert "enumerar"
+  eval: "eval"
+    # 🤔 @zoomstereo Not sure how will translate
+    # ❓ @asperduti "evaluar"
+    # ✅ @reegoram "evaluar"
+    # ✅ @kararade "evaluar"
+    # ✅ @JJgar2725 "evaluar"
+    # ✅ @aliciacisnerosm "evaluar"
+    # ✅ @iam-agf "evaluar"
+    # ✅ @begeistert "evaluar"
+  exec: "ejecutar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  filter: "filtrar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  float: "flotante"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  format: "formato"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  frozenset: "congelar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf It's needed to mention that the literal translation is "conjunto congelado"
+    # ✅ @begeistert
+  getattr: "obtener atributo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  globals: "globales"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  hasattr: "tiene atributo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  hash: "hash"
+    # ✅ @zoomstereo its direct translation wont make sense in this context
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725 I agree, keeping hash is fine
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  help: "ayuda"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  hex: "hexadecimal"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  id: "identificador"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725 or just id is fine as well
+    # ✅ @aliciacisnerosm id sounds okay
+    # ✅ @iam-agf Like the comments before, "id" is also ok, but also "identidad"
+    # ✅ @begeistert
+  input: "entrada"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  int: "entero"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  isinstance: "es instancia"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  issubclass: "es subclase"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  iter: "iterador"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  len: "longitud"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  list: "lista"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  locals: "locales"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  map: "mapa"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  max: "máximo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "máximo"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  memoryview: "vista de memoria"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  min: "mínimo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "mínimo"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  next: "siguiente"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  object: "objeto"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  oct: "octal"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  open: "abrir"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  ord: "ord"
+    # 🤔 @zoomstereo  I don't know how I would traslate this
+    # ❓ @asperduti "representación unicode"
+    # ❓ @reegoram What about "código unicode"?
+    # ❓ @kararade  I agree with "representación unicode"
+    # ❓ @JJgar2725 not entirely sure on this one, código unicode sounds okay
+    # ✅ @aliciacisnerosm
+    # ❓ @iam-agf The literal way to translate this one is impossible, but the action is accuarate with the word written there.
+    # ❓ @begeistert I don't know how I would traslate this
+  pow: "potencia"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  print: "imprimir"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  property: "propiedad"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  range: "rango"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  repr: "repr"
+    # 🤔 @zoomstereo can't be direct translated
+    # ✅ @asperduti "representación"
+    # ✅ @reegoram "representación"
+    # ✅ @kararade "representación"
+    # ✅ @JJgar2725 "representación"
+    # ✅ @aliciacisnerosm "representación"
+    # ✅ @iam-agf "representación"
+    # ✅ @begeistert "representación"
+  reversed: "invertido"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  round: "redondear"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  set: "asignar"
+    # ✅ @zoomstereo it is not the direct translation but in this context it makes sense
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  setattr: "asignar atributo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  slice: "rebanada"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "cortar"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  sorted: "ordenado"
+    # ✅ @zoomstereo
+    # ❓ @asperduti "ordenar"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  staticmethod: "metodo estatico"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf "método estático"
+    # ✅ @begeistert "método estático"
+  str: "cadena de texto"
+    # ✅ @zoomstereo
+    # ✅ @asperduti "cadena de texto"
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf Also it's possible to say "cadena de caracteres"
+    # ✅ @begeistert
+  sum: "suma"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  super: "superior"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ❓ @reegoram What about using padre?
+    # ❓ @kararade I think this should be just "super" as it is the way an object allows the developer to refer to its parent class
+    # ✅ @JJgar2725 keeping super would make sense, I agree with that
+    # ✅ @aliciacisnerosm "super" sound fine
+    # ✅ @iam-agf But also "padre" or "super" can be considered as valid
+    # ✅ @begeistert "super" sound fine
+  tuple: "tupla"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  type: "tipo"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  vars: "variables"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  zip: "zip"
+    # 🤔 @zoomstereo can't be direct translated
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+  __import__: "importar"
+    # ✅ @zoomstereo
+    # ✅ @asperduti
+    # ✅ @reegoram
+    # ✅ @kararade
+    # ✅ @JJgar2725
+    # ✅ @aliciacisnerosm
+    # ✅ @iam-agf
+    # ✅ @begeistert
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/fi.yml
+++ b/locale/fi.yml
@@ -1,0 +1,2004 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "fi"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: "abstrakti"
+  # ✅ @minna-xD
+continue: "sivuuta"
+  # ✅ @minna-xD: make sure final Python (etc.) translation is the same
+for: "kunnes"
+  # ✅ @minna-xD
+new: "uusi"
+  # ✅ @minna-xD
+switch: "valinta"
+  # ✅ @minna-xD
+assert: "edellytä"
+  # ✅ @minna-xD: make sure final Python (etc.) translation is the same
+default: "oletus"
+  # ✅ @minna-xD
+goto: "siirry"
+  # ✅ @minna-xD
+package: "paketti"
+  # ✅ @minna-xD
+synchronized: "synkronoitu"
+  # ✅ @minna-xD
+boolean: "totuusarvo"
+  # ✅ @minna-xD
+do: "tee"
+  # ✅ @minna-xD
+if: "jos"
+  # ✅ @minna-xD
+private: "yksityinen"
+  # ✅ @minna-xD
+this: "tämä"
+  # ✅ @minna-xD
+break: "katkaise"
+  # ✅ @minna-xD: make sure final Python (etc.) translation is the same
+double: "tarkkaliukuluku"
+  # ❓ @minna-xD
+implements: "toteuttaa"
+  # ✅ @minna-xD
+protected: "suojattu"
+  # ✅ @minna-xD
+throw: "heitä"
+  # ❓ @minna-xD: 'aiheuta'?
+byte: "tavu"
+  # ✅ @minna-xD
+else: "muuten"
+  # ✅ @minna-xD: make sure final Python (etc.) translation is the same
+import: "tuo"
+  # ✅ @minna-xD
+public: "julkinen"
+  # ✅ @minna-xD
+throws: "heittää"
+  # ❓ @minna-xD: 'aiheuttaa'?
+case: "tapaus"
+  # ✅ @minna-xD
+enum: "lueteltutyyppi"
+  # ❓ @minna-xD
+instanceof: "onkoluokkaa"
+  # ❓ @minna-xD
+return: "palauta"
+  # ✅ @minna-xD: make sure final Python (etc.) translation is the same
+transient: "tilapäinen"
+  # ✅ @minna-xD
+catch: "sieppaa"
+  # ❓ @minna-xD: 'havaitse'?
+extends: "perii"
+  # ❓ @minna-xD: sananmukaisesti 'laajentaa'
+int: "kokonaisluku"
+  # ✅ @minna-xD
+short: "pienikokonaisluku"
+  # ✅ @minna-xD
+try: "kokeile" 
+  # ✅ @minna-xD: : make sure final Python (etc.) translation is the same
+char: "merkki"
+  # ✅ @minna-xD
+final: "vakio"
+  # ❓ @minna-xD: 'muuttumaton'
+interface: "rajapinta"
+  # ✅ @minna-xD
+static: "staattinen"
+  # ✅ @minna-xD
+void: "tyhjä"
+  # ❓ @minna-xD
+class: "luokka"
+  # ✅ @minna-xD
+finally: "lopuksi"
+  # ✅ @minna-xD: : make sure final Python (etc.) translation is the same
+long: "isokokonaisluku"
+  # ✅ @minna-xD
+strictfp: "tarkkalaskenta"
+  # ❓ @minna-xD
+volatile: "yhteinen"
+  # ❓ @minna-xD
+const: "vakio"
+  # ❓ @minna-xD: or perhaps this should be removed, final is used instead
+float: "liukuluku"
+  # ✅ @minna-xD
+native: "ulkoinen"
+  # ❓ @minna-xD
+super: "yliluokka"
+  # ✅ @minna-xD
+while: "kun"
+  # ✅ @minna-xD: : make sure final Python (etc.) translation is the same
+_: "_" #_(underscore)
+  # ✅ @minna-xD
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "epätosi"
+    # ✅ @rouskuli 
+    # ✅ @minna-xd
+  None: "eimitään"
+    # ✅ @rouskuli: mitään, tyhjä
+    # ❓ @minna-xd: "puuttuva"
+  True: "tosi"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  and: "ja"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  as: "kuin"
+    # ❓ @rouskuli
+    # ❓ @minna-xd: "nimellä"
+  assert: "totea"
+    # ✅ @rouskuli
+    # ❓ @minna-xd: "edellytä", "oleta"
+  async: "eriaikainen"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  await: "odota"
+    # ✅ @rouskuli
+    # ❓ @minna-xd: "odota" ok, tai "tauko"
+  break: "katkaise"
+    # ✅ @rouskuli: keskeytä, lopeta; 
+    # ✅ @minna-xd: "katkaise" ok, aika luontevaa että silmukka katkaistaan(?)
+  class: "luokka"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  continue: "sivuuta"
+    # ✅ @rouskuli: jatka, ohita; 
+    # ❓ @minna-xd: "alkuun"? "sivuuta" aika hyvä myös
+  def: "määritä"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  del: "poista"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  elif: "jooten"
+    # ❓ @rouskuli: josten?, "vaihtoehto";
+    # ❓ @minna-xd: "vaihtoehto" on nokkela!
+  else: "muuten" # @rouskuli @minna-xd: ❓ 
+    # ✅ @rouskuli: muutoin?;
+    # ❓ @minna-xd: itse tykkäisin "muutoin" mutta se voi olla tuntemattomampi sanana (vanhahtava?), 
+    #               "muuten" on merkitykseltään oikea
+  except: "poikkeus"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  finally: "lopuksi"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  for: "kunnes"
+    # ❓ @rouskuli: varten ei käy, muuta?, kohde?, kohteelle?;
+    # ❓ @minna-xd: "muuttuja", "muuttujalle"? Note the somewhat different syntax in Python for 'for' loop
+  from: "jostain"
+    # ✅ @rouskuli
+    # ❓ @minna-xd: "lähde", "lähteestä"?
+  global:  "yleinen"
+    # ✅ @rouskuli
+    # ✅ @minna-xd: "yleinen" ok, tai "yhteinen"?
+  if: "jos"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  import: "tuo"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  in: "sisältyy"
+    # ❓ @rouskuli: "sisällä"
+    # ❓ @minna-xd: "joukossa"?
+  is: "on"
+    # ✅ @rouskuli
+    # ✅ @minna-xd: tai "sama"?
+  lambda: "lambda"
+    # ✅ @rouskuli
+    # ❓ @minna-xd:  "nimetön", "anonyymi"?
+  nonlocal: "ulkoinen"
+    # ❓ @rouskuli: epäpaikallinen, vieras;
+    # ❓ @minna-xd: "laajennettu"?, "ulkoinen" kyllä ihan hyvä
+  not: "ei"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  or: "tai"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  pass: "ohita"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  raise: "nosta"
+    # ✅ @rouskuli
+    # ❓ @minna-xd:  "varoita", "huomauta"?
+  return: "palaa"
+    # ❓ @rouskuli: vai palauta?
+    # ❓ @minna-xd: "palauta", koska se palauttaa arvon
+  try: "kokeile"
+    # ✅ @rouskuli
+    # ✅ @minna-xd
+  while: "kun"
+    # ✅ @rouskuli
+    # ✅ @minna-xd: ihan kielen päällä joku ytimekäs vastine "niin kauan kuin" -rakenteelle mutta ei tule päähän!
+  with: "käyttäen"
+    # ❓ @rouskuli: käytä
+    # ❓ @minna-xd: "käyttäen" vaikuttaa sopivalta (tai miksei "käytä")
+  yield: "väistä" # @minna-xd: ❓ 
+    # ✅ @rouskuli
+    # ❓ @minna-xd: "tuota" (ts. "generoi"), tai lennokkaasti keksitty "yksitellen"?
+
+# << Built-In Functions >>
+
+  abs: "itseisarvo"
+    # ✅ @minna-xd
+  all: "kaikki"
+    # ❓ @minna-xd: tai jopa 'kaikki-tosia'
+  any: "mikä-tahansa"
+    # ❓ @minna-xd: tai 'joku-totta' (ks. edellinen)
+  ascii: "asciiksi"
+    # ✅ @minna-xd: näissä tekee mieli käyttää -ksi, joka selventää että muunnetaan joksikin
+  bin: "binääriksi"
+    # ✅ @minna-xd
+  bool: "totuusarvoksi"
+    # ✅ @minna-xd
+  breakpoint: "keskeytyskohta"
+    # ✅ @minna-xd
+  bytearray: "tavutaulukoksi"
+    # ✅ @minna-xd
+  bytes: "tavuolioksi"
+    # ✅ @minna-xd
+  callable: "kutsuttavissa"
+    # ✅ @minna-xd
+  chr: "merkiksi"
+    # ✅ @minna-xd
+  classmethod: "luokkametodiksi"
+    # ✅ @minna-xd
+  compile: "käännä"
+    # ❓ @minna-xd: tämä lienee virallinen termi mutta aika monitulkintainen, 'koodiksi'? 'suoritettavaksi'?
+  complex: "kompleksiksi"
+    # ❓ @minna-xd: tai 'kompleksiluvuksi'
+  delattr: "poista-attribuutti"
+    # ✅ @minna-xd
+  dict: "sanakirjaksi"
+    # ✅ @minna-xd
+  dir: "hakemisto"
+    # ✅ @minna-xd
+  divmod: "osamäärä-jakojäännös"
+    # ✅ @minna-xd
+  enumerate: "numeroi"
+    # ✅ @minna-xd
+  eval: "arvioi"
+    # ✅ @minna-xd
+  exec: "suorita"
+    # ✅ @minna-xd
+  filter: "suodata"
+    # ✅ @minna-xd
+  float: "liukuluvuksi"
+    # ✅ @minna-xd
+  format: "muotoile"
+    # ✅ @minna-xd
+  frozenset: "lukituksi-joukoksi"
+    # ✅ @minna-xd
+  getattr: "hae-attribuutti"
+    # ✅ @minna-xd
+  globals: "yleiset"
+    # ✅ @minna-xd: varmista, että lopuksi sama sanavalinta kuin edellä 'global'
+  hasattr: "onko-attribuuttia"
+    # ✅ @minna-xd
+  hash: "hajautusarvo"
+    # ✅ @minna-xd
+  help: "ohje"
+    # ✅ @minna-xd
+  hex: "heksadesimaaliksi"
+    # ✅ @minna-xd
+  id: "tunniste"
+    # ✅ @minna-xd
+  input: "pyydä-syötettä"
+    # ❓ @minna-xd: tai ihan vain 'syöte', mutta se on monitulkintainen
+  int: "kokonaisluvuksi"
+    # ✅ @minna-xd
+  isinstance: "onko-luokkaa"
+    # ✅ @minna-xd
+  issubclass: "onko-aliluokka"
+    # ✅ @minna-xd
+  iter: "iteraattori"
+    # ✅ @minna-xd: tekisi mieli keksiä suomalainen vastine, mutta vaikeaa
+  len: "pituus"
+    # ✅ @minna-xd
+  list: "luetteloksi"
+    # ✅ @minna-xd
+  locals: "paikalliset"
+    # ✅ @minna-xd
+  map: "suorita-alkioille"
+    # ✅ @minna-xd
+  max: "suurin"
+    # ✅ @minna-xd
+  memoryview: "muistinäkymäksi"
+    # ❓ @minna-xd: tämä on itselleni outo käsite, joten epävarma käännösehdotus
+  min: "pienin"
+    # ✅ @minna-xd
+  next: "seuraava"
+    # ✅ @minna-xd
+  object: "olio"
+    # ✅ @minna-xd
+  oct: "oktaaliksi"
+    # ✅ @minna-xd
+  open: "avaa"
+    # ✅ @minna-xd
+  ord: "merkkipaikka"
+    # ✅ @minna-xd
+  pow: "potenssiin"
+    # ✅ @minna-xd
+  print: "tulosta"
+    # ✅ @minna-xd
+  property: "ominaisuus"
+    # ✅ @minna-xd
+  range: "lukujonoksi"
+    # ✅ @minna-xd
+  repr: "esitysmuoto"
+    # ✅ @minna-xd
+  reversed: "käänteinen"
+    # ✅ @minna-xd
+  round: "pyöristä"
+    # ✅ @minna-xd
+  set: "joukko"
+    # ✅ @minna-xd
+  setattr: "aseta-attribuutti"
+    # ✅ @minna-xd
+  slice: "osajoukoksi"
+    # ✅ @minna-xd
+  sorted: "järjestetty"
+    # ✅ @minna-xd
+  staticmethod: "staattiseksi-metodiksi"
+    # ✅ @minna-xd
+  str: "merkkijonoksi"
+    # ✅ @minna-xd
+  sum: "summaa"
+    # ✅ @minna-xd
+  super: "yliluokka"
+    # ✅ @minna-xd
+  tuple: "monikoksi"
+    # ✅ @minna-xd
+  type: "tyyppi"
+    # ❓ @minna-xd: tai 'laji', ikuinen ongelma :)
+  vars: "muuttujat"
+    # ✅ @minna-xd
+  zip: "yhdistä"
+    # ✅ @minna-xd
+  __import__: "__tuo__"
+    # ✅ @minna-xd
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/fr.yml
+++ b/locale/fr.yml
@@ -1,0 +1,1820 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "fr"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Faux" # ✓✓✓
+  None: "Nul"  # ? Previously: Null. Could be nul (masc) or nulle (fem), but french language defaults to masculine. || ✓ Agree on "Nul" as translation. More likely to be in masc form || ✓ Agree too on "Nul", the fem version is less used
+  True: "Vrai" # ✓✓✓
+  and: "et" # ? Previously: and. Translation should be 'et' || ✓ Agree on "et" || ✓
+  as: "comme"  # ✓✓✓
+  assert: "affirme" # ? Previously: Affirmer. Affirmer is closer to meaning "to assert". I believe the present tense would be more intuitive. || ✓ Agree on use of present tense, rather than infinitive 'affirmer'|| ✓
+  async: "asynchrone" # :thinking: Previously: Asynchrone. Like we don't use the full word asynchronous in english, a shorthand is likely fine || ✓ Agree on use of shorthand (and same for below shorthands) || 🤔 I would put "asynchrone" as "async" doesn't exist in french
+  await: "attend" # ? Previously: attendre. Verb tense || ✓✓
+  break: "interrompre" # ? Previously: Arreter. Arreter means 'to stop', which is not quite the same usage as break. Tricky, went with more literal 'casse' || ✓ Agree that "casse" is closer to the meaning, as you 'break' the loop || ? I would put "interrompre" as it stops the loop, "casse" is more when you break an object
+  class: "classe" # ✓✓✓
+  continue: "continue" # ? Previously: continuer. Verb tense || ✓✓
+  def: "déf" # ? Previously: définir. Shorthand || ✓ But could also be put in present tense as "définit", but "déf" is fine, as it is in English as "def" || ✓
+  del: "efface" # ? Previously: supprimer. Sup means to suppress, efface means erase, feels closer + more intuitive || ? "supprime" could work too, meaning 'removes'. I often see 'supprime' relating to computing and data, but 'efface' would work too || ✓
+  elif: "sinon si" # ✓✓✓
+  else: "sinon" # ✓✓✓
+  except: "excepte" # ? Previously: Excepter. Verbe tense. Thought 'sauf' might work as well, but this feels more explicit || ✓ agree on "excepte" || ✓
+  finally: "finalement" # ✓✓✓
+  for: "pour" # ✓✓✓
+  from: "de" # ✓✓✓
+  global:  "global" # ✓✓ || ? "Global" does not have an -e at the end
+  if: "si" # ✓✓✓
+  import: "importe" # Previously: importer. Verb tense || ✓✓
+  in: "dans" # ✓✓✓
+  is: "est" # ✓✓✓
+  lambda: "lambda" # ✓✓✓
+  nonlocal: "nonlocal" # Previously: non locale. Don't think we should have 2 word keywords? || ✓ || ? word "local" does not have an -e at the end, "exterieur" which means outside (not inside) would be an option too
+  not: "non" # ✓✓✓
+  or: "ou" # ✓✓✓
+  pass: "passe" # ? Previously: Passer. Verb tense || ✓✓
+  return: "retourne" # ? Previously: retourner. Verb tense || ✓✓
+  raise: "lève" # Previously: lever. Verb tense + accent || ✓✓
+  try: "essaye" # Previously: essayer. Verb tense || ✓✓
+  while: "tantque" # ✓ Nice, like this better than 'pendant' || ✓✓
+  with: "avec" # ✓✓
+  yield: "produit" # ? Previously: produire. Verb tense || ✓✓
+
+# << Built-In Functions >>
+
+  abs: "abs" # ? Previously: absolue. Shorthand || ✓✓
+  all: "tout" # ✓✓✓
+  any: "nimporte" # Previously: peu importe. should be one word, n'importe means the same. || ✓ Agree on "nimporte" || ✓ "n'importe" is better in this case
+  ascii: "ascii" # ✓✓✓
+  bin: "bin" # ? Previously: binaire. Shorthand fits the same. || ✓ ✓
+  bool: "bool" # ? Previously: booléen. Shorthand fits the same. || ✓ || booléen is the right word: bool is a person while booléen is a variable
+  breakpoint: "point-arret" # ✓✓✓
+  bytearray: "chaine-octets" # ? Previously: chaine octets. Made one word. || ✓✓
+  bytes: "octets" # ✓✓✓
+  callable: "appelable" # ✓✓✓
+  chr: "caractère" # ? Previously: caractére. Fixed accent || ✓✓ 
+  classmethod: "méthodeclasse" # ? Previously: Methode de classe. Squashed to one word. || ✓✓
+  compile: "compile" # ✓✓✓
+  complex: "complexe" # ✓✓✓
+  delattr: "effaceattr" # ? Previously: supprimer attribut. One word, more accurate delete word. || ✓ Agree on 1 word, but, as above, could also "supprimeattr" || ✓
+  dict: "dict" # ? Previously: binaire. Shorthand fits the same. || ✓ Agree on "dict" || ✓
+  dir: "repertoire" # ✓✓✓
+  divmod: "divmod" # ? Previously: Division modulo. One word, shorthand fits fine || ✓✓
+  enumerate: "énumére" # ✓ || ? Could also be put in present tense as "énumère" || ✓ "énumère" is better for the cohesion
+  eval: "éval" # ? Previously: évaluer. Shorthand || ✓✓
+  exec: "exécute" # ? Previously: excevuter. Typo || ✓✓
+  filter: "filtre" # ✓✓✓
+  float: "flotant" # :thinking: Previously: flotant. Nothing exact here. || :thinking: --> previously "flotte". Seems that "flotant" is more commonly used referring to 'floats' || ✓ "flotant" is the right name of this variable
+  format: "format" # ✓✓✓
+  getattr: "chercheattr" # ? Previously: recupere attribut. One word, cherche is closer to 'find'. Recupere is closer to 'recover'. || ✓ agree on "chercheattr" || ✓
+  frozenset: "ensemblefigé" # ? Previously: ensemble figé. Made one word || ✓✓
+  hasattr: "possèdeattr" # ? Previously: a l'attribute. One word, more to the point. || ✓ || "àattr" is not very pretty, I would replace "à" with "possède" which has the same meaning
+  globals: "globaux" # ? Previously: Global. Pluralize || ✓✓
+  hash: "hachage" # ? Previously: tableau de hachage. More to the point. Might still be a better word for it perhaps. || ✓ agree on "hachage" || ✓
+  help: "aide" # ✓✓✓
+  hex: "hex" # Previously: hexadecimal. shorthand || ✓✓
+  id: "id" # Previously: identifier. Shorthand, not necessarily the verb form. || ✓✓
+  input: "entrée" # ✓✓✓
+  int: "entier" # :thinking: entier means 'whole'. Unsure about what's appropriate here. || ? if unclear, could be "nombre-entier", but "entier" should be ok too || "entier" is the right word for this variable
+  isinstance: "estinstance" # made one word || ✓✓
+  issubclass: "estsousclasse" # made one word || ✓✓
+  iter: "iter" # ? Previously: iteration. Shorthand || ✓✓
+  len: "longeur" # ? Previously: taille. Taille is typically a person's height. || ✓ || ✓ "longueur" and "taille" are right in this context
+  list: "liste" # ✓✓✓
+  locals: "locales" # ? Pluralized || ? Could also be "locaux" || ✓ "locales" is better as the fem version is more likely used than the masc one
+  map: "map" # :thinking: Unsure if this definition of map has a suitable french equivalent. This might be fine. || ✓ Don't think there is a more suitable term in French.. || ✓
+  max: "max" # ? Previously: maximum. shorthand || ✓✓
+  memoryview: "vuememoire" # ? Previously "". Added definition || ✓✓
+  min: "min" # ? previously: minimum. Shorthand || ✓✓
+  next: "prochain" # ? previously: suivant. Both are fair, but prochain feels closer to the usage. || ✓✓
+  object: "objet" # ✓✓✓
+  oct: "oct" # ? previously: octal. Shorthand || ✓✓
+  open: "ouvre" # ? Previously: overt. verb tense. || ✓✓
+  ord: "ord" # ? Previously: ordinal. Shorthand. || ✓✓
+  pow: "puissance" # ✓✓✓
+  print: "affiche" # ? Previously: afficer. Verb tense. Perhaps 'imprime' is more literal, as this means 'display', but that's the average usage in reality. || ✓ agree on "affiche" || ✓
+  property: "propriété" # ✓✓✓
+  range: "interval" # ✓✓
+  repr: "répr" # ? Previously: Répresentation. Shorthand || ✓✓
+  reversed: "renversé" # Previously: renverser. verb tense. || ✓✓
+  round: "arrondit" # Previously: arrondir. Verb tense. || ✓✓
+  set: "ensemble" # ✓✓✓
+  setattr: "défattr" # Previously: attribuer. verb tense. Perhaps should be more explicit, as it's also the noun. || ? could also be "définit-attr" or "déf-attr" to translate the 'set' part as well || ✓ It is more likely "défattr" as "set" is missing
+  slice: "tranche" # ✓✓✓
+  sorted: "trié" # ? Previously: trier. Verb tense. || ✓✓
+  staticmethod: "méthodestatique" # made one word. || ✓✓
+  str: "chaîne" # :thinking: No direct translation here. Perhaps we leave as 'str'. || ? tough one. Could shorten to "chaîne" || ✓ "chaîne" and "chaînedecaractére" are used
+  sum: "somme" # ✓✓✓
+  super: "super" # ✓✓✓
+  tuple: "tuple" # ✓✓✓
+  type: "type" # ✓✓✓
+  vars: "variables" # ? previously: variables. Shorthand || ✓ || "vars" is not very correct, it's more likely "variables"
+  zip: "zip" # ✓✓✓
+  __import__: "__import__" # ✓✓✓
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/ga.yml
+++ b/locale/ga.yml
@@ -1,0 +1,1827 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+Database: bunachar sonraí
+
+dearbhaigh/fógair = declare, assert?
+
+else? eile
+
+abstract?
+set = set variable or set theory?
+
+while = i rith/le linn/tamall/seal/nuair
+
+where = áite/cá bhfuil
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "ga"
+
+# ----------------------
+# |    SYSTEM: ATOM (ADAMH)   |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "NÓTA"
+  INFO: "EOLAS"
+  IDEA: "TUALEIS"
+  DEBUG: "DÍFHABHTAIGH"
+  REMOVE: "AISTRIGH"
+  OPTIMIZE: "?" #optamaigh/barrfheabhsaigh
+  REVIEW: "ATHBHREITHNIÚ"
+  HACK: "HAICEÁIL"
+  UNDONE: "" #cealaigh/cealaithe
+  TODO: "ÁDHEANAMH"
+  REFACTOR: "ATHFHACHTÓRIGH"
+  DEPRECATED: "GNÉ DHÍMHOLTA" #deprecated feature
+  TASK: "TASC"
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: "FABHT"
+  ERROR: "EARRÁID"
+  OMG: "ÓMD"
+  ERR: "EARRÁID" #?
+  OMFGRLY: ""
+  WARNING: "RABHADH"
+  WARN: "TABHAIR RABHADH"
+  BROKEN: BRISTÉ
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: "comhsonraí?"
+  coinductive: "comh?ionduchtaitheach?ionduchtach"
+  constructor: "cruthaitheoir"
+  data: "sonraí"
+  do: "déan"
+  eta-equality: "-cothroime "
+  field: "réimse"
+  forall: "dogach"
+  hiding: ""
+  import: "iompórtáil"
+  in: "isteach/istigh"
+  inductive: "ionductach?"
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: "ásc"
+  let: "lig"
+  macro: "macra"
+  module: "modúl"
+  mutual: "cómhalartach"
+  no-eta-equality: "-cothroime"
+  open: "oscailte"
+  overlap: "forluí/forluigh" #n/v?
+  pattern: "patrún"
+  postulate: "postaláidigh(br)/postaláid"
+  primitive: "buntéarma" #primitíbheach
+  private: "príobháideach"
+  public: "poiblí"
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: "athainmniú"
+  rewrite: "athscríobh"
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "comhréir"
+  tactic: "oirbheart"
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: "ag úsáid? grammar"
+  where: "áite/cá bhfuil"
+  with: "leis"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "dean" # (part of do-while statement)
+while: ""
+for: "do"
+if: "más" # (part of if-else statement)
+else: "ná" # (part of if-else statement)
+switch: "lasc"
+break: "bristé" # (part of the switch statement or for/while statements)
+case: "cás" # (part of the switch statement)
+continue: "lean ar" # (part of for/while statements)
+default: "réamhshocrú" # (part of switch statement)
+function: "feidhm"
+procedure: "fo-oideas"
+return: "aisfhilleadh"
+local: "logánta"
+global: "domhanda"
+static: "statach"
+typeof: "cineál"
+NOT: ""
+AND: "AGUS"
+OR: "NÓ"
+Null: "Nialasach"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "cás/tuiseal"
+do: "déan"
+done: "déanta"
+elif: "eile"
+else: "nó"
+esac: "sác/leasiut"
+fi: "sám"
+for: "do"
+function: "feidhm"
+if: "más"
+in: "isteach"
+select: "roghnaigh"
+then: "ansin"
+time: "ám"
+until: "go"
+while: "i rith/le linn"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "uath"
+double: "dúbailte"
+int: "slánuimhir"
+struct: "struchtúr"
+break: "bris"
+else: ""
+long: "fada"
+switch: "lasc"
+case: "cás"
+enum: "áirigh"
+register: "cláraigh"
+typedef: "cineál"
+char: "carachtar"
+extern: "seachtrach"
+return: "aisfhilleadh"
+union: "aontas"
+const: "tairiseach"
+float: "snámhphointe"
+short: "gairid/gearr"
+unsigned: "gan sín"
+continue: "lean ar"
+for: "do"
+signed: "le sín"
+void: "folamh/folúntas"
+default: "réamhshocrú"
+goto: "dulgodtí"
+sizeof: "méidede?"
+volatile: "luaineach"
+do: "déan"
+if: "más"
+static: "statach"
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: "sainigh/sainmhínigh"
+#defined: "sainithe/sainmhínithe"
+#elif: "eile más?"
+#else: ""
+#endif: "críocnaigh más"
+#error: "earráid"
+#if: "más"
+#ifdef: ""
+#ifndef: ""
+#include: "cuimsigh"
+#line: "líne"
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: "agus"
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: "bris"
+case: "cás"
+catch: "gabháil"
+char: "carachtar"
+char16_t: "carachtar16_?"
+char32_t: "carachtar32_"
+class: "aicme"
+compl: ""
+concept: "coincheap"
+const: "tairiseach"
+constexpr: "tairiseach?"
+const_cast: "tairiseach?"
+continue: "lean ar"
+decltype: "?cineál"
+default: "réamhshocrú"
+delete: "scrios"
+do: "déan"
+double: "dúbailte"
+dynamic_cast: "_dinimiciúil"
+else: ""
+enum: "áirigh"
+explicit: "léir"
+export: "easpórtáil"
+extern: "seachtrach"
+false: "breagach"
+final: "deireanach"
+float: "snámhphointe" ###
+for: "do"
+friend: "cara"
+goto: "dulgodtí"
+if: "más"
+inline: "inlíne"
+int: "slánuimhir"
+import: "iompórtáil"
+long: "fada"
+module: "modúl"
+mutable: "athraithe"
+namespace: "ainmspás"
+new: "nua"
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: "oibreoir"
+or: "nó"
+or_eq: ""
+override: "sárú"
+private: "príobháideach"
+protected: "cosanta"
+public: "poiblí"
+register: "cláraigh"
+reinterpret_cast: ""
+requires: ""
+return: "aisfhilleadh"
+short: "gairid/gearr"
+signed: "le sín"
+sizeof: ""
+static: "statach"
+static_assert: "dearbhaigh_statach"
+static_cast: "statach_"
+struct: "struchtúr"
+switch: "lasc"
+synchronized: "sioncronaigh"
+template: "teimpléad"
+this: "seo"
+thread_local: "_logánta"
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: "_dinimiciúil"
+true: "fíor"
+try: "triail"
+typedef: "cineál"
+typeid: "cineál"
+typename: "cineál"
+union: "aontas"
+unsigned: "gan sín"
+using: ""
+virtual: "fhíorúil"
+void: "folamh/folúntas"
+volatile: "luaineach"
+wchar_t: "carachtar?"
+while: ""
+xor: "eisiach OR"
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: "cuir le"
+alias: "ailias"
+as: ""
+ascending: "ardaitheach"
+async: "neamsioncronaigh"
+await: "fan le"
+base: ""
+bool: "bool"
+break: "bris"
+byte: "ochtán"
+case: "cás"
+catch: "gabháil"
+char: "carachtar"
+checked: ""
+class: "aicme"
+const: "tairiseach"
+continue: "lean ar"
+decimal: "deachúil"
+default: "réamhshocrú"
+delegate: "toscaire?"
+descending: "íslitheach"
+do: "déan"
+double: "dúbailte"
+dynamic: "dinimiciúil"
+else: ""
+enum: "áirigh"
+event: "teagmhas"
+explicit: "léir"
+extern: "seachtrach"
+false: "breagach"
+finally: "faoi dheireadh"
+fixed: "fosaithe" #nó seasta
+float: "snámhphointe" ###http://www.potafocal.com/gt/?s=r%C3%ADomhaire
+for: "do"
+foreach: ""
+from: "ó"
+get: "faigh"
+global: "domhanda"
+goto: "dulgodtí"
+group: "grúpa"
+if: "má"
+implicit: "" infhillte/intuigthe
+in: "isteach"
+int: "slánuimhir"
+interface: "comhéadan"
+internal: "inmhéanach"
+into: "isteach"
+is: ""
+join: "comcheangail"
+let: "lig"
+lock: "glas"
+long: "fada"
+namespace: "ainmspás"
+new: "nua"
+null: "nialasach"
+object: "oibiacht"
+operator: "oibreoir"
+orderby: "chur in ord de réir"
+out: "amach"
+override: "sárú"
+params: "paraiméadair"
+partial: "páirteach?"
+private: "príobháideach"
+protected: "cosanta"
+public: "poiblí"
+readonly: "inléiteamháin"
+ref: "tagairt"
+remove: "cuir le?is"
+return: "aisfhilleadh"
+sbyte: "*ochtán"
+sealed: "séalaithe"
+select: "roghnaigh"
+set: ""
+short: "gearr"
+sizeof: ""
+stackalloc: "cruachleithdháil"
+static: "statach"
+string: "teaghrán"
+struct: "struchtúr"
+switch: "lasc"
+this: "seo"
+throw: ""
+true: "fíor"
+try: "triail"
+typeof: "cineál"
+uint: "?slánuimhir"
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: "luach"
+var: "athróg"
+virtual: "fhíorúil"
+void: "folamh/folúntas"
+volatile: "luaineach"
+where: "áite/cá bhfuil"
+while: ""
+yield: "toradh"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "ailínigh" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "ailínigh-airteagal" #	Specifies the alignment for items inside a flexible container
+align-self: "ailínigh" #	Specifies the alignment for selected items inside a flexible container
+all: "gach" #	Resets all properties (except unicode-bidi and direction)
+animation: "anamúlacht" #	A shorthand property for all the animation-* properties
+animation-delay: "-anamúlacht" #	Specifies a delay for the start of an animation
+animation-direction: "treo-anamúlacht" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "fad-anamúlacht" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "anamúlacht" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "cuntas-anamúlacht" #	Specifies the number of times an animation should be played
+animation-name: "ainm-anamúlacht" #	Specifies a name for the @keyframes animation
+animation-state: "cruth-anamúlacht" #	Specifies whether the animation is running or paused
+animation-function: "anamúlacht" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "cúlra" #	A shorthand property for all the background-* properties
+background-attachment: "cúlra" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "cúlra" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "cúlra" #	Defines how far the background (color or image) should extend within an element
+background-color: "dath-cúlra" #	Specifies the background color of an element
+background-image: "íomhá-cúlra" #	Specifies one or more background images for an element
+background-origin: "cúlra" #	Specifies the origin position of a background image
+background-position: "cúlra" #	Specifies the position of a background image
+background-repeat: "cúlra" #	Sets if/how a background image will be repeated
+background-size: "cúlra" #	Specifies the size of the background images
+border: "imeall" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "bun-imeall" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "dath-imeall" #	Sets the color of the bottom border
+border-radius: "imeall" #	Defines the radius of the border of the bottom-left corner
+border-radius: "imeall" #	Defines the radius of the border of the bottom-right corner
+border-style: "stíl-imeall" #	Sets the style of the bottom border
+border-width: "imeall" #	Sets the width of the bottom border
+border-collapse: "imeall-cliseadh" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "imeall-dath" #	Sets the color of the four borders
+border-image: "íomhá-imeall" #	A shorthand property for all the border-image-* properties
+border-outset: "imeall" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "imeall" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "imeall" #	Specifies how to slice the border image
+border-source: "foinseach-imeall" #	Specifies the path to the image to be used as a border
+border-width: "leithead-imeall" #	Specifies the width of the border image
+border-left: "clé-imeall" #	A shorthand property for all the border-left-* properties
+border-color: "dath-imeall" #	Sets the color of the left border
+border-style: "stíl-imeall" #	Sets the style of the left border
+border-width: "leithead-imeall" #	Sets the width of the left border
+border-radius: "imeall" #	A shorthand property for the four border-*-radius properties
+border-right: "imeall-deis" #	A shorthand property for all the border-right-* properties
+border-color: "dath-imeall" #	Sets the color of the right border
+border-style: "imeall" #	Sets the style of the right border
+border-width: "leithead-imeall" #	Sets the width of the right border
+border-spacing: "imeall" #	Sets the distance between the borders of adjacent cells
+border-style: "stíl-imeall" #	Sets the style of the four borders
+border-top: "barr-imeall" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "dath-imeall" #	Sets the color of the top border
+border-radius: "-imeall" #	Defines the radius of the border of the top-left corner
+border-radius: "-imeall" #	Defines the radius of the border of the top-right corner
+border-style: "stíl-imeall" #	Sets the style of the top border
+border-width: "leithead-imeall" #	Sets the width of the top border
+border-width: "leithead-imeall" #	Sets the width of the four borders
+bottom: "bun" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "bris-tar-éis" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "brís-" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "-dath" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "@carachtar?" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "dath" #	Sets the color of text
+column-count: "colún" #	Specifies the number of columns an element should be divided into
+column-fill: "colún" #	Specifies how to fill columns, balanced or not
+column-gap: "colún" #	Specifies the gap between the columns
+column-rule: "colún" #	A shorthand property for all the column-rule-* properties
+column-color: "dath-colún" #	Specifies the color of the rule between columns
+column-style: "stíl-colún" #	Specifies the style of the rule between columns
+column-width: "colún" #	Specifies the width of the rule between columns
+column-span: "colún" #	Specifies how many columns an element should span across
+column-width: "leithead" #	Specifies the column width
+columns: "colúin" #	A shorthand property for column-width and column-count
+content: "inneachar" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "cúrsóir" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "taispeántas" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "sgagaire" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "snámh" #	Specifies whether or not a box should float
+font: "cló" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "cló" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "fine-cló" #	Specifies the font family for text
+font-settings: "socruithe-cló" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "cló" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "cló" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "sárú-cló" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "cló" #	Specifies the font size of text
+font-adjust: "cló" #	Preserves the readability of text when font fallback occurs
+font-stretch: "cló" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "stíl-cló" #	Specifies the font style for text
+font-synthesis: "cló" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "cló" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "cló" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "cló" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "cló" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "nasclitreacha-cló"? #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "cló" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "cló" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "cló" #	Specifies the weight of a font
+grid: "greille" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "achar-greille" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "colúin-greille" #	Specifies a default column size
+grid-flow: "greille" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "greille" #	Specifies a default row size
+grid-column: "greille" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "greille" #	Specifies where to end the grid item
+grid-gap: "greille" #	Specifies the size of the gap between columns
+grid-start: "greille" #	Specifies where to start the grid item
+grid-gap: "greille" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "greille" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "greille" #	Specifies where to end the grid item
+grid-gap: "greille" #	Specifies the size of the gap between rows
+grid-start: "greille" #	Specifies where to start the grid item
+grid-template: "teimpléad-greille" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "achair-?rgreille" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "colúin-greille" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "greille" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "airde" #	Sets the height of an element
+hyphens: "fleiscíní" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "íomhá" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "@iompórtáil" #	Allows you to import a style sheet into another style sheet
+isolation: "leithlisiú" #	Defines whether an element must create a new stacking content
+justify-content: "fírinnigh-inneachar" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "clé" #	Specifies the left position of a positioned element
+letter-spacing: "spásáil-carachtar" #	Increases or decreases the space between characters in a text
+line-break: "bris-líne" #	Specifies how/if to break lines
+line-height: "airde-líne" #	Sets the line height
+list-style: "stíl" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "ciumhais" #	Sets all the margin properties in one declaration
+margin-bottom: "bun-ciumhais" #	Sets the bottom margin of an element
+margin-left: "clé-ciumhais" #	Sets the left margin of an element
+margin-right: "deis-ciumhais" #	Sets the right margin of an element
+margin-top: "barr-ciumhais" #	Sets the top margin of an element
+max-height: "airde-uasta" #	Sets the maximum height of an element
+max-width: "leithead-uasta" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "airde-íosta" #	Sets the minimum height of an element
+min-width: "leithead-íosta" #	Sets the minimum width of an element
+mix-mode: "modh-measc?" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "oibiacht-" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "oibiacht-" #	Specifies the alignment of the replaced element inside its box
+opacity: "teimhneacht" #	Sets the opacity level for an element
+order: "chur in ord" #	Sets the order of the flexible item, relative to the rest
+orphans: "dílleachtaí" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "imlíne" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "dath-imlíne?" #	Sets the color of an outline
+outline-offset: "imlíne?" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "stíl-imlíne" #	Sets the style of an outline
+outline-width: "leithead-imlíne" #	Sets the width of an outline
+overflow: "róshreabhadh?" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "róshreabhadh?" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "róshreabhadh?-x" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "róshreabhadh?-y" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "stuáil" #	A shorthand property for all the padding-* properties
+padding-bottom: "bunn-stuáil" #	Sets the bottom padding of an element
+padding-left: "clé-stuáil" #	Sets the left padding of an element
+padding-right: "deis-stuáil" #	Sets the right padding of an element
+padding-top: "barr-stuáil" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "peirspictíocht" #	Gives a 3D-positioned element some perspective
+perspective-origin: "peirspictíocht" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "-pointeora" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "deis" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "-tábla" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "ailínigh" #	Specifies the horizontal alignment of text
+text-last: "téacs" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "téacs" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "téacs" #	Specifies the decoration added to text
+text-color: "dath-téacs" #	Specifies the color of the text-decoration
+text-line: "líne-téacs" #	Specifies the type of line in a text-decoration
+text-style: "stíl-téacs" #	Specifies the style of the line in a text decoration
+text-indent: "téacs" #	Specifies the indentation of the first line in a text-block
+text-justify: "téacs" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "téacs" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "téacs" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "téacs" #: "" 	#Adds shadow to text
+text-transform: "téacs" #: "" 	#Controls the capitalization of text
+text-position: "téacs" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "barr" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "roghnaigh-féin" #	Specifies whether the text of an element can be selected
+vertical-align: "ailínigh" #	Sets the vertical alignment of an element
+visibility: "infheictheacht" #	Specifies whether or not an element is visible
+white-space: "spás-bán" #	Specifies how white-space inside an element is handled
+widows: "baintreacha" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "leithead" #	Sets the width of an element
+word-break: "focail" #	Specifies how words should break when reaching the end of a line
+word-spacing: "focail" #	Increases or decreases the space between words in a text
+word-wrap: "focail" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "modh-" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "-z" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: "bris"
+default: "réamhshocrú"
+func: "feidhm"
+interface: "comhéadan"
+select: "roghnaigh"
+case: "cás"
+defer: "" géill (opinion or judgment), or iarchuir (defer)
+go: "téigh"
+map: "mapáil"
+struct: "struchtúr"
+chan: ""
+else: ""
+goto: "téigh go"
+package: "pacáiste"
+switch: "lasc"
+const: "tairiseach"
+fallthrough: ""
+if: "má"
+range: "raon"
+type: "cineál"
+continue: "lean ar"
+for: "do"
+import: "iompórtáil"
+return: "aisfhilleadh"
+var: "athróg"
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: "mar"
+case: "cás"
+of: ""
+class: "aicme"
+data: "sonraí"
+data family: "fine sonraí"
+data instance: "ásc sonraí"
+default: "réamhshocrú"
+deriving: ""
+deriving instance: "ásc "
+do: "déan"
+forall: "dogach"
+foreign: ""
+hiding: ""
+if: "má"
+then: "ansin"
+else: ""
+import: "iompórtáil"
+infix: ""
+infixl: ""
+infixr: ""
+instance: "ásc"
+let: "lig"
+in: ""
+mdo: ""
+module: "modúl"
+newtype: "cineálnua"
+proc: ""
+qualified: "cáilithe"
+rec: ""
+type: "cineál"
+type family: "fine cineál"
+type instance: "cineál ásc" #? asc de cineal
+where: "áite/cá bhfuil"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "cineál" #	Defines the document type
+a: "a" #	Defines a hyperlink
+abbr: "gior" #	Defines an abbreviation or an acronym
+acronym: "acrainm" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "seoladh" #	Defines contact information for the author/owner of a document
+applet: "feidhmchláirín" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "achar" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "seachfhocal" #	Defines content aside from the page content
+audio: "closán" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "mór" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "cabhail" #	Defines the document's body
+br: "br" #	Defines a single line break
+button: "cnaipe" #	Defines a clickable button
+canvas: "canbhás" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "fotheideal" #	Defines a table caption
+center: "lár" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "luaigh" #	Defines the title of a work
+code: "cód" #	Defines a piece of computer code
+col: "colún" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "grupacolún?sp" #	Specifies a group of one or more columns in a table for formatting
+data: "sonraí" #	Links the given content with a machine-readable translation
+datalist: "liostasonraí" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "scrios:" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "leabaigh" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "cló" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "foirm" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "ceann" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "íomhá" #	Defines an image
+input: "ionchur " #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "méarchlár" #	Defines keyboard input
+label: "lipéad" #	Defines a label for an <input> element
+legend: "eochaireolais" #	Defines a caption for a <fieldset> element
+li: "al" #	Defines a list item (airteagal liosta)
+link: "nasc" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "meiteashonraí" #	Defines metadata about an HTML document
+meter: "méadar" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "oibiacht" #	Defines an embedded object
+ol: "lo" #	Defines an ordered list ("liosta ordaithe")
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "rogha" #	Defines an option in a drop-down list
+output: "aschur" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "araiméadair" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "dulchunchin" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "samp" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "roghnaigh" #	Defines a drop-down list
+small: "beag" #	Defines smaller text
+source: "foinseach" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "láidir/bríomhar" #	Defines important text
+style: "stíl" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "achoimre" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "svg" #	Defines a container for SVG graphics
+table: "tábla" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "teimpléad" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "am" #	Defines a date/time
+title: "teideal" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "rian?" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "liosta gan ord" #	Defines an unordered list
+var: "athróg" #	Defines a variable
+video: "fístéip" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: "lean"
+for: "do"
+new: "nua"
+switch: "lasc/cas"
+assert: "dearbhaigh"
+default: "réamhshocrú"
+goto: "téigh go"
+package: "pacáiste"
+synchronized: "sioncronaithe"
+boolean: "oibritheoir Boole"
+do: "déan"
+if: "má"
+private: "príobháideach"
+this: "seo"
+break: "brís"
+double: "dúbailte"
+implements: ""
+protected: "cosanta"
+throw: "caith" #?
+byte: "ochtán/bearta" #?
+else: "ná"
+import: "iompórtáil"
+public: "poiblí"
+throws: "caitheamh" #?
+case: "cás"
+enum: "áirigh"
+instanceof: "ásc de"
+return: "aisfhilleadh"
+transient: "neambhuain" #tearma
+catch: "gabháil"
+extends: "?" Síneann (strech)/ leathnaíonn (expand) [sé]
+int: "slánuimhir"
+short: "gairid/gearr"
+try: "triail"
+char: "carachtar"
+final: "deireanach"
+interface: "comhéadan"
+static: "statach"
+void: "folamh/folúntas"
+class: "aicme"
+finally: "faoi dheireadh"
+long: "fada"
+strictfp: "docht?"
+volatile: "luaineach" #tearma
+const: "tairiseach"
+float: "snámhphointe"
+native: "dúchasach"
+super: "os"
+while: ""
+_: "_" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: "argóintí"
+await: "fan ar?/le"
+break: "bris"
+case: "cás"
+catch: "gabháil"
+class: "aicme"
+const: "tairiseach"
+continue: "lean ar"
+debugger: "dífhabhtóir"
+default: "réamhshocrú"
+delete: "scrios"
+do: "déan"
+else: ""
+enum: "áirigh"
+eval: "luacháil"
+export: "easpórtáil"
+extends: "?" Síneann (strech)/ leathnaíonn (expand) [sé]
+false: "breagach/falsa"
+finally: "faoi dheireadh"
+for: "do"
+from: "ó"
+function: "feidhm"
+if: "má"
+implements: "uirlisí?"
+import: "iompórtáil"
+in: ""
+instanceof: "ásc de"
+interface: comhéadan"
+let: "lig"
+new: "nua"
+null: "nialasach"
+package: "pacáiste"
+private: "príobháideach"
+protected: "cosanta"
+public: "poiblí"
+return: "aisfhilleadh"
+static: "statach"
+super: "os"
+switch: "lasc"
+this: "seo"
+throw: "caith"
+true: "fíor"
+try: "triail"
+typeof: "cineál"
+var: "athróg"
+void: "folamh/folúntas"
+while: ""
+with: "leis"
+yield: "toradh"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: "tosaigh"
+while: "tamall"
+if: "má"
+for: "do"
+try: "triail"
+return: "aisfhilleadh"
+break: "bris"
+continue: "lean ar"
+function: "feidhm"
+macro: "macra"
+quote: "arsa"
+let: "lig"
+local: "logánta"
+global: "domhanda"
+const: "tairiseach"
+do: "déan"
+struct: "struchtúr"
+abstract: "" #to be deprecated
+typealias: "?ailias" #to be deprecated
+bitstype: "" #to be deprecated
+type: "cineál" #to be deprecated
+immutable: "do-athraithe"  #to be deprecated
+module: "modúl"
+baremodule: "?modúl"
+using: ""
+import: "iompórtáil"
+export: "easpórtáil"
+importall: "iompórtáilgach"
+end: "críochnaigh"
+else: ""
+catch: "gabháil"
+finally: " faoi dheireadh"
+true: "fíor"
+false: "breagach"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "@rochtain" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "@ailias" # Treat a member as if it had a different name.
+@async: "@neamsioncronaigh" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "@údar" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "@aicme" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "@?aicme" # Use the following text to describe the entire class.
+@constant: "@tairiseach" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "@cóipcheart" # Document some copyright information.
+@default: "@réamhshocrú" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "@gnédhímholta" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "@áirigh" # Document a collection of related properties.
+@event: "@teagmhas" # Document an event.
+@example: "@sampla" # Provide an example of how to use a documented item.
+@exports: "@easpórtálacha" # Identify the member that is exported by a JavaScript module.
+@external: "@seachtrach" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "@comhad" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "@feidhm" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "@domhanda" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "déan neamhaird de" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "@comhéadan" # This symbol is an interface that others can implement.
+@kind: "@" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "@modúl" #Document a JavaScript module.
+@name: "@ainm" #Document the name of an object.
+@namespace: "@ainmspás" #Document a namespace object.
+@override: "@sárú" #Indicate that a symbol overrides its parent.
+@package: "@pacáiste" # This symbol is meant to be package-private.
+@param: "@paraiméadair" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "@príobháideach" #This symbol is meant to be private.
+@property: "@airí" #(synonyms: @prop) Document a property of an object.
+@protected: "@cosanta" #This symbol is meant to be protected.
+@public: "@poiblí" #This symbol is meant to be public.
+@readonly: "@inléiteamháin" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "feach" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "@statach" #Document a static member.
+@summary: "@achoimre" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "@ádheanamh" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "@cinéal" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "{@nasc}" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: "$scéim"
+$ref: "$tagairt"
+$id: "$aitheantas"
+$comment: "$trácht"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: "__eolainm" #eolaí
+__filename: "__comhadainm"
+exports: "easpórtáilach" #grammar
+module: "modúl"
+require: "teastáil" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "agus" #
+as: "mar" #
+assert: "dearbhaigh" #
+asr: "" #
+begin: "tosaigh" #
+class: "aicme" #
+constraint: "iallach" #
+do: "déan" #
+done: "déanta" #
+downto: "" #
+else: "" #
+end: "críoch" #
+exception: "" #
+external: "seachtrach" #
+false: "breagach" #
+for: "do" #
+fun: "" #
+function: "feidhm" #
+functor: "" #
+if: "má" #
+in: "i" #
+include: "cuimsigh" #
+inherit: "faigh br le hoidhreacht/
+faigh br ó oidhreacht/
+faigh br trí oidhreacht/" #
+initializer: "tosaitheoir" #
+land: "" #
+lazy: "leithsceal" #
+let: "lig" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "cuir le" #
+method: "modh" #
+mod: "" #
+module: "modúl" #
+mutable: "athraithe" #
+new: "nua" #
+nonrec: "" #
+object: "oibiacht" #
+of: "" #
+open: "oscail" #
+or: "nó" #
+private: "príobháideach" #
+rec: "" #
+sig: "" #
+struct: "struchtúr" #
+then: "ansin" #
+to: "" #
+true: "fíor" #
+try: "triail" #
+type: "cineál" #
+val: "luach" #
+virtual: "fhíorúil" #
+when: "nuair" #
+while: "" #
+with: "leis" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: "_stad_tiomsaitheoir"
+abstract: ""
+and: "agus"
+array: ""
+as: ""
+break: "bris"
+callable: ""
+case: "cás"
+catch: "gabháil"
+class: "aicme"
+clone: "?" #clón (n)/clónáil(v)
+const: "tairiseach"
+continue: "lean ar"
+declare: "dearbhaigh"
+default: "réamhshocrú"
+die: "éag"
+do: "déan"
+echo: "macalla"
+else: ""
+elseif: ""
+empty: "folamh"
+enddeclare: "críochnaighdearbhaigh"
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: "críoch-lasc"
+endwhile: ""
+eval: "luacháil"
+exit: "téigh amach"
+extends: ""
+final: "deireanach"
+for: ""
+foreach: ""
+function: "feidhm"
+global: "domhanda"
+goto: "téigh go"
+if: "má"
+implements: ""
+include: "cuimsigh"
+include_once: "cuimsigh_uair"
+instanceof: "ásc de"
+insteadof: ""
+interface: "comhéadan"
+isset: ""
+list: "liostaigh"
+namespace: "ainmspás"
+new: "nua"
+or: "nó"
+print: "priontáil"
+private: "príobháideach"
+protected: "cosantach"
+public: "poiblí"
+require: "gátar?"
+require_once: "gátar_amhain?"
+return: "aisfhilleadh"
+static: "statach"
+switch: "lasc"
+throw: "rad?"
+trait: "tréith"
+try: "triail"
+unset: ""
+use: "úsáid"
+var: "athróg"
+while: ""
+xor: "XOR??"
+__CLASS__: "__AICME__"
+__DIR__: "_EOLAIRE_"
+__FILE__: "__COMHAD__"
+__FUNCTION__: "__FEIDHM__"
+__LINE__: "__LÍNE__"?
+__METHOD__: "__MODH__"
+__NAMESPACE__: "__AIMNSPÁS__"
+__TRAIT__: "__TRÉITH__"
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Breagach"
+  None: ""
+  True: "Fíor"
+  and: "agus"
+  as: "mar"
+  assert: "dearbhaigh"
+  async: "neamsioncronaithe/neamsioncronaigh"
+  await: ""
+  break: "bris"
+  class: "aicme"
+  continue: "lean ar"
+  def: ""
+  del: "scrios"
+  elif: ""
+  else: ""
+  except: "eisceadh"
+  finally: " faoi dheireadh"
+  for: "do"
+  from: "ó"
+  global:  "domhanda"
+  if: "má"
+  import: "iompórtáil"
+  in: ""
+  is: ""
+  lambda: "lambda"
+  nonlocal: "neamhlogánta"
+  not: ""
+  or: "nó"
+  pass: ""
+  raise: ardaigh
+  return: "aisfhilleadh"
+  try: "triail"
+  while: ""
+  with: "leis"
+  yield: "toradh"
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: "gach"
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: "brisphointe"
+  bytearray: "ochtán*"
+  bytes: "ochtán*"
+  callable: ""
+  chr: ""
+  classmethod: "aicme"
+  compile: "tiomsú"
+  complex: "choimpléascach"
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: "áirigh"
+  eval: "luacháil"
+  exec: ""
+  filter: "sgagaire"
+  float: "snámhphointe "
+  format: ""
+  frozenset: ""
+  getattr: "faighaitreabúid"
+  globals: "domhandacha"
+  hasattr: "aitreabúid"
+  hash: "hais"
+  help: "cabhair"
+  hex: ""
+  id: "aitheantas"
+  input: "ionchuir"
+  int: "slánuimhir"
+  isinstance: ""
+  issubclass: "?aicme"
+  iter: ""
+  len: ""
+  list: "liostaigh"
+  locals: "logántai?"
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: "oibiacht"
+  oct: ""
+  open: "oscail"
+  ord: ""
+  pow: ""
+  print: "pr"
+  property: "airí"
+  range: "raon"
+  repr: ""
+  reversed: ""
+  round: "slánaigh"
+  set: ""
+  setattr: "aitreabúid"
+  slice: ""
+  sorted: ""
+  staticmethod: "modhstatach"
+  str: ""
+  sum: "suim" #suimigh?
+  super: "os"
+  tuple: "codach"
+  type: "cineál"
+  vars: ""
+  zip: ""
+  __import__: "__iompórtáil__"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "ainmspás" #
+functions: "feidhmeanna" #
+inherits: "" #faighte a3 le hoidhreacht
+model: "eiseamláireach" #
+section: "alt/gearradh" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "@cás" #
+@do: "@déan" #
+@default: "@réamhshocrú" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "@glas" #
+@switch: "@lasc" #
+@try: "@triail" #
+@catch: "@gabháil" #
+@finally: "@faoi dheireadh" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: "ailias"
+and: "agus"
+begin: "tosaigh"
+break: "brís"
+case: "cás"
+class: "aicme"
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: "críoch"
+ensure: ""
+false: "breagach"
+for: ""
+if: ""
+in: "isteach"
+module: "modúl"
+next: ""
+nil: "neamhní"
+not: ""
+or: "nó"
+redo: "athdhéan"
+rescue: "tarrtháil"
+retry: "atriail"
+return: "aisfhilleadh"
+self: ""
+super: "os"
+then: "ansin"
+true: "fíor"
+undef: ""
+unless: "mura"
+until: "go"
+when: ""
+while: "tamall/seal"
+yield: "toradh"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: "bris"
+const: "tairiseach"
+continue: "lean ar"
+crate: ""
+do: "déan"
+else: ""
+enum: "áirigh"
+extern: ""
+false: "breagach"
+final: "deireanach"
+fn: ""
+for: ""
+if: "má"
+impl: ""
+in: ""
+let: "lig"
+loop: "lúb"
+macro: "macra"
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: "sárú"
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: "tagairt"
+return: "aisfhilleadh"
+Self: ""
+self: ""
+sizeof: ""
+static: "statach"
+struct: "struchtúr"
+super: "os"
+trait: "tréith"
+true: "fíor"
+type: "cineál"
+typeof: "cineál"
+unsafe: ""
+unsized: ""
+use: "toradh"
+virtual: "fhíorúil"
+where: "áite/cá bhfuil"
+while: ""
+yield: "toradh"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: "cás"
+catch: "gabháil"
+class: "aicme"
+def: ""
+do: "dêan"
+else: ""
+extends: ""
+false: "breagach"
+final: "deireanach"
+finally: "faoi dheireadh"
+for: ""
+forSome: ""
+if: "má"
+implicit: "?"
+import: "iompórtáil"
+lazy: "leithsceal"
+macro: "macra"
+match: "cuir le chéile"
+new: "nua"
+null: "nialasach"
+object: "oibiacht"
+override: "sárú"
+package: "pacáiste"
+private: "príobháideach"
+protected: "cosanta"
+return: "aisfhilleadh"
+sealed: "séalaithe"
+super: "os"
+this: "seo"
+throw: "caith"
+trait: "tréith"
+try: "triail"
+true: "fíor"
+type: "cineál" #saghas, sórt
+val: "luach"
+var: "athróg"
+while: ""
+with: "leis"
+yield: "toradh"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: "cineál?"
+class: "aicme"
+deinit: "dítúsaigh"
+enum: "áirigh"
+extension: "" #iarmhír (file extension)/ breisiú (In coding theory, the process of encoding several symbols at a time, or the results thereof.)
+func: "feidhm"
+import: "iompórtáil"
+init: "túsaigh"
+inout: ""
+internal: "inmheánach"
+let: "lig"
+operator: "oibritheoir"
+private: "príobháideach"
+protocol: "prótacal"
+public: "poiblí"
+static: "statach"
+struct: "struchtúr"
+subscript: "foscript" #?
+typealias: "ailiascineál"
+var: "athróg"
+break: "bris"
+case: "cás"
+continue: "lean ar"
+default: "réamhshocrú"
+defer: "iarchuir/géill" postpone/judgment
+do: "déan"
+else: ""
+fallthrough: ""
+for: "do"
+guard: "fair"
+if: "mâ"
+in: "istigh"
+repeat: "athdhéan"
+return: "aisfhilleadh"
+switch: "lasc"
+where: "áite"
+while: ""
+as: "mar"
+catch: "gabháil"
+dynamicType: "dinimiciúil?"
+false: "breagach"
+is: ""
+nil: "neamhní"
+rethrows: ""
+super: "os"
+self: "féin"
+Self: "Féin"
+throw: ""
+throws: ""
+true: "fíor"
+try: "triail"
+#column: ""
+#file: "comhad"
+#function: "#feidhm"
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: "comhad"
+#function: "#feidhm"
+#if: "má"
+#line: ""
+#selector: "roghnaighnó"
+associativity: "comhcheangaltacht"
+convenience: "áis"
+dynamic: "dinimiciúil"
+didSet: ""
+final: "deireanach"
+get: "faigh"
+infix: ""
+indirect: "indíreach"
+lazy: "leithsceal"
+left: "clé"
+mutating: ""
+none: ""
+nonmutating: ""
+optional: "roghnach"
+override: "sárú"
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: "ardheis"
+set: ""
+Type: "Cineál"
+unowned: ""
+weak: "" lag (lacking in strength) nó éadrom (light)
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: "bris"
+case: "cás"
+catch: "gabháil"
+class: "aicme"
+const: "tairiseach"
+continue: "lean ar"
+debugger: "dífhabhtóir"
+default: "réamhshocrú"
+delete: "scrios"
+do: "déan"
+else: ""
+enum: "áirigh"
+export: "easpórtáil"
+extends: ""
+false: "breagach"
+finally: "faoi dheireadh"
+for: ""
+function: "feidhm"
+if: "má"
+import: "iompórtáil"
+in: "isteach"
+instanceof: "ásc de"
+new: "nua"
+null: "nialasach"
+return: "aisfhilleadh"
+super: "os"
+switch: "lasc"
+this: "sin" #?
+throw: "caith"
+true: "fíor"
+try: "triail"
+typeof: "cineál?"
+var: "athróg"
+void: "folamh/folúntas"
+while: ""
+with: "leis"
+as: ""
+implements: ""
+interface: "comhéadan"
+let: "lig"
+package: "pacáiste"
+private: "príobháideach"
+protected: "cosanta"
+public: "poiblí"
+static: "statach"
+yield: "toradh"
+any: "aon"
+boolean: "boole"
+constructor: "cruthaitheoir"
+declare: "dearbhaigh/fógair"
+get: "faigh"
+module: "modúl"
+require: "tai"
+number: "uimhir"
+set: ""
+string: "teaghrán"
+symbol: "siombail"
+type: "cineál"
+from: "ó"
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: "agus"
+assign: "sann"
+begin: "tosaigh"
+buf: ""
+bufif0: ""
+bufif1: ""
+case: "cás"
+casex: "cás"
+casez: "cás"
+cmos: ""
+deassign: "dísann"
+default: "réamhshocrú"
+defparam: "éamhshocrú"
+disable: "díchumasaigh"
+edge: ""
+else: ""
+end: "críoch"
+endcase: "críochcás?"
+endfunction: "críochfeidhm"
+endmodule: "críoch"
+endprimitive: "críoch?buntéarma" #primitíbheach"
+endspecify: "críoch"
+endtable: "críoch"
+endtask: "críoch"
+event: "teagmhas"
+for: ""
+force: "brúigh"
+forever: ""
+fork: "forc"
+function: "feidhm"
+highz0: ""
+highz1: ""
+if: "má"
+initial: "tosaigh?"
+inout: ""
+input: "ionchuir"
+integer: "slánuimhir"
+join: "comhcheangail"
+large: "mór"
+macromodule: "macramodúl"
+medium: "meán"
+module: "modúl"
+nand: "nand"
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: "nó"
+output: "aschur"
+pmos: ""
+posedge: ""
+primitive: "buntéarma" #primitíbheach
+pull0: "tarraing0"
+pull1: "tarraing1"
+pulldown: "tarraingsíos"
+pullup: "tarraingsuas"
+rcmos: ""
+reg: ""
+release: "eisigh(v)/eisigh(n)/scaoileadh"
+repeat: "athdhean"
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: "scálach?"
+small: "beag"
+specify: "sainigh"
+specparam: ""
+strong0: "láidir/tréan0"
+strong1: "láidir/tréan1"
+supply0: ""
+supply1: ""
+table: "tábla"
+task: "tasc"
+time: "ám"
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: "veicteoireach"
+wait: "fan"
+wand: "fagus"
+weak0: ""
+weak1: ""
+while: ""
+wire: "sreang?"
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/gu.yml
+++ b/locale/gu.yml
@@ -1,0 +1,2702 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "gu"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "નોંધ"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+  INFO: "માહિતી"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+  IDEA: "વિચાર"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+  DEBUG: ""
+    # 👀 @179priyasoni
+    # ❓ @aadii0408 - it would be more effective - "સુધારવુ"
+    # ✅ @shahkv95 "ખામી-સુધારવી"
+  REMOVE: "દૂર કરવું"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "દૂર-કરવું"
+  OPTIMIZE: ""
+    # 👀 @179priyasoni
+    # ❓ @aadii0408 - it would be more effective - "શક્ય ઍટલુ સારુ કરવુ"
+    # ✅ @shahkv95 "સુધારવું"
+  REVIEW: "સમીક્ષા"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+  HACK: ""
+    # 👀 @179priyasoni
+    # 🤔 @aadii0408
+    # ❓ @shahkv95 "હેક"
+  UNDONE: "પૂર્ણ ના થવું"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "પૂર્વવત્"
+  TODO: "આ કરવું"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ❓ @shahkv95 - unable to find anything better "આ-કરવું"
+  REFACTOR: ""
+    # 👀 @179priyasoni
+    # 🤔  @aadii0408
+    # ✅ @shahkv95  "પુનઃરચના"
+  DEPRECATED: "નાપસંદ"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ❓ @shahkv95 - Need to confirm once - as નાપસંદ means dislike which does not deprecated
+  TASK: "કાર્ય"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+  CHGME: ""
+    # 👀 @179priyasoni
+    # 🤔  @aadii0408
+    # ❓ @shahkv95 - unsure about the keyword itself
+  NOTREACHED: "સુધી પહોંચ્યું નથી"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "ન-પહોચવું "
+  WTF: "અશબ્દ"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "વાહિયાત"
+  BUG: "ભૂલ"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "ખામી"
+  ERROR: "ભૂલ"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+  OMG: "હે રામ"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "હે-રામ"
+  ERR: ""
+    # 👀 @179priyasoni
+    # 🤔  @aadii0408
+    # ✅ @shahkv95 "સંકેત-ભૂલ"
+  OMFGRLY: ""
+    # 👀 @179priyasoni
+    # 🤔  @aadii0408
+    # ❓ @shahkv95 - unsure about the keyword itself
+  WARNING: "ચેતવણી"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+  WARN: "ચેતવણી આપવી"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95 "સંકેત-ચેતવણી"
+  BROKEN: "તૂટેલું"
+    # ✅ @179priyasoni
+    # ✅ @aadii0408
+    # ✅ @shahkv95
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "કરવું" # (part of do-while statement)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+while: "જ્યારે"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+for: "માટે"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+if: "જો" # (part of if-else statement)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+else: "નહિ તો" # (part of if-else statement)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "નહિ-તો"
+switch: ""
+  # 👀 @179priyasoni
+  # 🤔  @aadii0408
+  # ✅ @shahkv95 "ફેરફાર"
+break: "વિરામ" # (part of the switch statement or for/while statements)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+case: "બાબત" # (part of the switch statement)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+continue: "ચાલુ રાખવું" # (part of for/while statements)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "ચાલુ-રાખવું"
+default: "મૂળભૂત" # (part of switch statement)
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+function: "કાર્ય"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+procedure: "પ્રક્રિયા"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+return: "પાછું આપવું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ❓ @shahkv95  "પાછું-આપવું", but how about - "પરત"
+local: "સ્થાનિક"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+global: "વૈશ્વિક"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+static: ""
+  # 👀 @179priyasoni
+  # 🤔  @aadii0408
+  # ✅ @shahkv95  "સ્થિર"
+typeof: "પ્રકાર"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+NOT: "નથી"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+AND: "અને"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+OR: "અથવા"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+Null: "ખાલી"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "અસ્તિત્વમાં-નથીી"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "મુકદ્દમો"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "મૂલ્ય"
+do: "કરવું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+done: "થઈ ગયું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "પૂર્ણ"
+elif: "એલિફ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "અન્ય-જો"
+else: "નહિતો"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "અન્ય"
+esac: ""
+  # 👀 @179priyasoni
+  # 👀 @aadii0408
+  # ❓ @shahkv95 - "ઈ-એસ-એ-સી" unsure about the word itself - it's a keyword and not a word
+fi: ""
+  # 👀 @179priyasoni
+  # 👀 @aadii0408
+  # ✅ @shahkv95 "અંત"
+for: "માટે"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+function: "કાર્ય"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+if: "જો"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+in: "ની અંદર"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "અંદર"
+select: "પસંદ કરવું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "પસંદ-કરવું"
+then: "પછી"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+time: "સમય"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+until: "ત્યાં સુધી"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95 "ત્યાં-સુધી"
+while: "જ્યારે"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+  # ✅ @shahkv95
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "સ્વયં"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+double: "બમણું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+int: "પૂર્ણાંક"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+struct: "માળખું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+break: "વિરામ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+else: "નહિતો"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+long: "લાંબુ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+switch: "સ્વિચ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+case: "મુકદ્દમો"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+enum: "ઇ સંખ્યા"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+register: "નોંધણી"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+typedef: ""
+  # 👀 @179priyasoni
+char: "મૂળાક્ષર"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+extern: "બાહ્ય"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+return: "પાછું આપવું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+union: "સંઘ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+const: "અચળ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+float: "અપૂર્ણાંક"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+short: "ટુંકું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+unsigned: "સહી વગરનું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+continue: "ચાલુ રાખવું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+for: "માટે"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+signed: "હસ્તાક્ષર કર્યા"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+void: "શૂન્ય"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+default: "મૂળભૂત"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+goto: "પર જાઓ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+sizeof: "નું કદ"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+volatile: "અસ્થિર"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+do: "કરવું"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+if: "જો"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+static: "સ્થિર"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+while: "જ્યારે"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: "અમૂર્ત"
+  # ✅  @nik132-eng
+continue: "ચાલુ રાખો"
+  # ✅  @nik132-eng
+for: "માટે"
+  # ✅  @nik132-eng
+new: "નવું"
+  # ✅  @nik132-eng
+switch: "સ્વિચ"
+  # ✅  @nik132-eng
+assert: "દાવો કરવો"
+  # ✅  @nik132-eng
+default: "મૂળભૂત"
+  # ✅  @nik132-eng
+goto: "પર જાઓ"
+  # ✅  @nik132-eng
+package: "પેકેજ"
+  # ✅  @nik132-eng
+synchronized: "સમન્વયિત"
+  # ✅  @nik132-eng
+boolean: "બુલિયન"
+  # ✅  @nik132-eng
+do: "કરવું"
+  # ✅  @nik132-eng
+if: "જો"
+  # ✅  @nik132-eng
+private: "ખાનગી"
+  # ✅  @nik132-eng
+this: "આ"
+  # ✅  @nik132-eng
+break: "વિરામ"
+  # ✅  @nik132-eng
+double: "ડબલ"
+  # ✅  @nik132-eng
+implements: "સાધનો"
+  # ✅  @nik132-eng
+protected: "સુરક્ષિત"
+  # ✅  @nik132-eng
+throw: "ફેંકવું"
+  # ✅  @nik132-eng
+byte: "બાઇટ"
+  # ✅  @nik132-eng
+else: "બીજું"
+  # ✅  @nik132-eng
+import: "આયાત"
+  # ✅  @nik132-eng
+public: "જાહેર"
+  # ✅  @nik132-eng
+throws: "ફેંકી દે છે"
+  # ✅  @nik132-eng
+case: "કેસ"
+  # ✅  @nik132-eng
+enum: "enum"
+  # ✅  @nik132-eng
+instanceof: "ઉદાહરણ તરીકે"
+  # ✅  @nik132-eng
+return: "પરત"
+  # ✅  @nik132-eng
+transient: "ક્ષણિક"
+  # ✅  @nik132-eng
+catch: "પકડો"
+  # ✅  @nik132-eng
+extends: "વિસ્તરે છે"
+  # ✅  @nik132-eng
+int: "પૂર્ણાંક"
+  # ✅  @nik132-eng
+short: "ટૂંકા"
+  # ✅  @nik132-eng
+try: "પ્રયત્ન કરો"
+  # ✅  @nik132-eng
+char: "ચાર"
+  # ✅  @nik132-eng
+final: "અંતિમ"
+  # ✅  @nik132-eng
+interface: "ઈન્ટરફેસ"
+  # ✅  @nik132-eng
+q: "q"
+  # ✅  @nik132-eng
+void: "રદબાતલ"
+  # ✅  @nik132-eng
+class: "વર્ગ"
+  # ✅  @nik132-eng
+finally: "છેલ્લે"
+  # ✅  @nik132-eng
+long: "લાંબી"
+  # ✅  @nik132-eng
+strictfp: "hardfp"
+  # ✅  @nik132-eng
+volatile: "અસ્થિર"
+  # ✅  @nik132-eng
+C: "સી"
+  # ✅  @nik132-eng
+float: "તરવું"
+  # ✅  @nik132-eng
+native: "મૂળ"
+  # ✅  @nik132-eng
+super: "સુપર"
+  # ✅  @nik132-eng
+while: "જ્યારે"
+  # ✅  @nik132-eng
+_: "underscore" #_(underscore)
+  # ✅  @nik132-eng
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+False: "ખોટું"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+None: "કંઈ નહીં"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+True: "સાચું"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+and: "અને"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+as: "જેમ કે"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "તરીકે"
+  # ✅ @136tejas "તરીકે" and "જેમ કે" both translations are true
+  # ✅ @179priyasoni
+  # 👀 both are true
+assert: "દાવો"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+async: "async"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "અસુમેળ"
+  # ❓ @136tejas "અસુમેળ" is better translation
+  # ❓ @179priyasoni "અસમન્વય"
+  # ✅ @nik132-eng "અસુમેળ" is proper
+await: "રાહ જોવી"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+break: "વિરામ"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "તોડવું" is better for ending a loop
+  # ❓ @136tejas "તોડવું"
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+class: "વર્ગ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+continue: "ચાલુ રાખો"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+def: "def"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "વ્યાખ્યા કરવી" is better for defining a function.
+  # ❓ @136tejas "વ્યાખ્યાયીત કરવું"
+  # ❓ @179priyasoni "વ્યાખ્યાયીત કરવું"
+  # ✅ @nik132-eng "વ્યાખ્યાયીત કરવું"
+del: "ડેલ"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "કાઢી નાખવું". "ડેલ is phonetic translation.
+  # ❓ @136tejas "કાઢી નાખવું"
+  # ❓ @179priyasoni "કાઢી નાખવું"
+  # ✅ @nik132-eng "કાઢી નાખવું"
+elif: "એલિફ"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "અન્યથા જો"
+  # ❓ @136tejas "બીજું જો" and "અન્યથા જો" both translations are true
+  # ❓ @179priyasoni "બીજું જો"
+  # ❓ @nik132-eng "અન્યથા જો"
+else: "બીજું"
+  # ✅ @bvishal8510
+  # 🤔 @sshiv5768 I think "નહિતો" looks perfect.
+  # ❓ @136tejas "નહિતો"
+  # 🤔 @179priyasoni "નહિતર" and "નહિતો"
+  # 👀 @nik132-eng "નહિતો"
+except: "સિવાય"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+finally: "છેવટે"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+for: "માટે"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+from: "માંથી"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+global: "વૈશ્વિક"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+if: "જો"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+import: "આયાત કરો"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+in: "માં"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+is: "છે"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+lambda: "લેમ્બડા"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # 👀 @179priyasoni
+  # ✅ @nik132-eng
+nonlocal: "નોનલોકલ"
+  # ✅ @bvishal8510
+  # 🤔 @sshiv5768 I think "બિન સ્થાનિક" would be more suitable. "નોનલોકલ" is phonetic translation.
+  # ❓ @136tejas "સ્થાનિક નહીં" and "બિન સ્થાનિક" both are suitable for nonlocal.
+  # 👀 @179priyasoni
+  # ❓ @nik132-eng "બિન સ્થાનિક"
+not: "નથી"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ❓ @136tejas "નહીં" is more suitable
+  # ❓ @179priyasoni "નથી" and "નહીં" both are right
+  # ✅ @nik132-eng
+or: "અથવા"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+pass: "પસાર"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "પાસ"
+  # 🤔 @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng "પસાર" is better
+raise: "વધારો"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "ઊભું કરવું" is more suitable whenever we use try-except for error handling in Python.
+  # 🤔 @136tejas
+  # ✅ @179priyasoni
+  # 🤔 @nik132-eng
+return: "પાછા"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+try: "પ્રયાસ કરો"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+while: "જ્યારે"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "જ્યાં સુધી" is perfect because we use while as a loop
+  # ❓ @136tejas "જ્યાં સુધી"
+  # 👀 @179priyasoni
+  # ❓ @nik132-eng "જ્યાં સુધી"
+with: "સાથે"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+yield: "ઉપજ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # ✅ @136tejas
+  # ✅ @179priyasoni
+  # ✅ @nik132-eng
+
+# << Built-In Functions >>
+
+abs: "એબીએસ"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 I think "સંપૂર્ણ" fits better for abs, which returns absolute value.
+  # 👀 @136tejas
+  # 👀 @Nidhir2k1
+  # ✅ @nik132-eng
+all: "બધા"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+any: "કોઈપણ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+ascii: "ascii"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+bin: "ડબ્બા"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 I think "દ્વિસંગી" is perfect for bin because "ડબ્બા" represents boxes, which is not meaningful.
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+bool: "બુલ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+breakpoint: "બ્રેકપોઇન્ટ"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 I think "વિરામ બિંદુ" suits better than "બ્રેકપોઇન્ટ"
+  # 👀 @136tejas
+  # ❓ @Nidhir2k1 I think અલ્પવિરામ is better
+  # ❓ @nik132-eng I think "વિરામ બિંદુ"
+bytearray: "બાયટ્રે"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # 🤔 @Nidhir2k1 Dont think there is a translation
+  # ✅ @nik132-eng
+bytes: "બાઇટ્સ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+callable: "બોલાવવા યોગ્ય"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+chr: "chr"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅  @nik132-eng
+classmethod: "વર્ગમૂળ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+compile: "સંકલન"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+complex: "જટિલ"
+  # ✅ @bvishal8510
+  # ✅ @sshiv5768
+  # 👀 @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+delattr: "delattr"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 I think phonetic translation will not work here, "લક્ષણ હટાવવા" fits better
+  # 👀 @136tejas
+  # ❓ @Nidhir2k1 Agree with "લક્ષણ હટાવવા"
+  # ❓ @nik132-eng "લક્ષણ હટાવવા"
+dict: "ડિક"
+  # ✅ @bvishal8510
+  # ❓ @sshiv5768 "કોશ" or "શબ્દકોશ" is perfect translation, because we use it as dictionary
+  # 👀 @136tejas
+  # ❓ @Nidhir2k1 "શબ્દકોશ" suits better
+  # ❓ @nik132-eng "શબ્દકોશ"
+dir: "dir"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas Maybe "નિર્દેશિકા"
+  # ❓ @Nidhir2k1 નિર્દેશિક translates it well
+  # ✅ @nik132-eng
+divmod: "divmod"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas maybe "વિભાગ મોડ"
+  # 🤔 @Nidhir2k1
+  # 🤔 @nik132-eng
+enumerate: "ગણતરી કરવી"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1 or you use ગણવું
+  # ✅ @nik132-eng
+eval: "ઇવલ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "મૂલ્યાંકન" is better translation for eval.
+  # ❓ @Nidhir2k1 "મૂલ્યાંકન" is better translation
+  # ❓ @nik132-eng "મૂલ્યાંકન"
+exec: "એક્ઝેક"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # 🤔 @Nidhir2k1
+  # 🤔 @nik132-eng
+filter: "ફિલ્ટર"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # 👀 @Nidhir2k1
+  # ✅ @nik132-eng
+float: "ફ્લોટ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+format: "બંધારણ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+frozenset: "સ્થિર"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "સ્થિર સમૂહ" is better translation for frozenset.
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+getattr: "getattr"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # 👀 @Nidhir2k1
+  # 🤔 @nik132-eng
+globals: "ગ્લોબલ્સ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "વૈશ્વિક" is better translation for globals.
+  # 🤔 @Nidhir2k1
+  # ❓ @nik132-eng "વૈશ્વિક"
+hasattr: "ઉતાવળ કરવી"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas  "ગુણ હોવા" or "વિશેષતા હોવી"
+  # 🤔 @Nidhir2k1
+  # ✅ @nik132-eng
+hash: "હેશ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+help: "મદદ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+hex: "હેક્સ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+id: "આઈડી"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+input: "ઇનપુટ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas maybe "દાખલ કરવું"
+  # ❓ @Nidhir2k1 "દાખલ કરવું" suits better
+  # ❓ @nik132-eng "દાખલ કરવું"
+int: "પૂર્ણાંક"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+isinstance: "isinstance"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "ઉદાહરણ તરીકે" is better translation for ininstance.
+  # 🤔 @Nidhir2k1
+  # 🤔 @nik132-eng
+issubclass: "ઇસ્યુબક્લાસ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "પેટા વર્ગ છે" is better translation for issubclass.
+  # ❓ @Nidhir2k1 "પેટા વર્ગ છે"
+  # ❓ @nik132-eng "પેટા વર્ગ છે"
+iter: "તે"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # ❓ @Nidhir2k1 પુનરાવર્તન
+  # 🤔 @nik132-eng
+len: "લેન"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "લંબાઈ" is better translation
+  # ❓ @Nidhir2k1 "લંબાઈ"
+  # ❓ @nik132-eng "લંબાઈ"
+list: "યાદી"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+locals: "સ્થાનિકો"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+map: "નકશો"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+max: "મહત્તમ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+memoryview: "મેમરીવ્યુ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # 🤔 @Nidhir2k1
+  # 🤔 @nik132-eng
+min: "મિનિટ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "ન્યૂનતમ" is better translation for min
+  # ❓ @Nidhir2k1 લઘુત્તમ is also a possible
+  # ✅ @nik132-eng
+next: "આગળ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+object: "objectબ્જેક્ટ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas  "વસ્તુ"
+  # ❓ @Nidhir2k1 "વસ્તુ" fits better
+  # ❓ @nik132-eng  "વસ્તુ"
+oct: "ઓક્ટો"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+open: "ખુલ્લા"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+ord: "ઓર્ડર"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+pow: "પાવ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "ઘાતાંક" or "વદી"
+  # ❓ @Nidhir2k1 "વદી"
+  # ❓ @nik132-eng "વદી"
+print: "છાપો"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1 or you can use લખો..though it changes the real translation but makes more sense for print function
+  # ✅ @nik132-eng
+property: "મિલકત"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+range: "શ્રેણી"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+repr: "repr"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # 👀 @Nidhir2k1
+  # ✅ @nik132-eng
+reversed: ".લટું"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "ઉલટું"
+  # ❓ @Nidhir2k1 "ઉલટું"
+  # ❓ @nik132-eng "ઉલટું"
+round: "ગોળ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+set: "સમૂહ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+setattr: "setattr"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # ❓ @Nidhir2k1 લક્ષણ સેટ કરો
+  # 👀 @nik132-eng
+slice: "કટકા"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+sorted: "સortedર્ટ થયેલ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "વર્ગીકૃત"
+  # 👀 @Nidhir2k1
+  # ✅ @nik132-eng
+staticmethod: "સ્થિર"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ❓ @Nidhir2k1 frozenst has the some translation
+  # ✅ @nik132-eng
+str: "str"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas I believe data types should be kept as it is just change them phonetically if needed
+  # ✅ @Nidhir2k1
+  # ✅  @nik132-eng
+sum: "સરવાળો"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅  @nik132-eng
+super: "સુપર"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅  @nik132-eng
+tuple: "tuple"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas I believe data types should be kept as it is just change them phonetically if needed
+  # 👀 @Nidhir2k1
+  # ✅ @nik132-eng
+type: "પ્રકાર"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ✅ @136tejas
+  # ✅ @Nidhir2k1
+  # ✅ @nik132-eng
+vars: "યુદ્ધો"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "ચલ"
+  # ❓ @Nidhir2k1
+  # ✅ @nik132-eng
+zip: "ઝિપ"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # 🤔 @136tejas
+  # 🤔 @Nidhir2k1
+  # ✅ @nik132-eng
+__import__: "__ મહત્વપૂર્ણ__"
+  # ✅ @bvishal8510
+  # 👀 @sshiv5768
+  # ❓ @136tejas "આયાત કરવું"
+  # ❓ @Nidhir2k1
+  # ✅ @nik132-eng
+
+# << Error Messages >>
+
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: "ઉપનામ"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+and: "અને"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+begin: "શરૂઆત"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+break: "વિરામ"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+case: "કેસ"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+class: "વર્ગ"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+def: "વ્યાખ્યા કરવી"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+defined?: "વ્યાખ્યાયિત?"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+do: "કરવું"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+else: "નહિતો"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+elsif: "અન્યથા જો"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+end: "અંત"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+ensure: "ખાતરી કરો"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+false: "ખોટું"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+for: "માટે"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+if: "જો"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+in: "માં"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+module: "મોડ્યુલ"
+  # ✅ @136tejas
+  # ❓ @aadii0408 (I think this should better) - "અલ્પ માત્રા"
+next: "આગળ"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+nil: "ખાલી"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+not: "નથી"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+or: "અથવા"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+redo: "બીજી વખત કરવું"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+rescue: "બચાવ"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+retry: "બીજી વખત પ્રયાસ"
+  # ✅ @aadii0408
+  # ✅ @136tejas
+return: "પરત"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+self: "સ્વ(પોતે)"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+super: "સુપર"
+  # ✅ @136tejas
+  # ✅ @aadii0408(I think this should be better) -"ઉત્તમ"
+then: "પછી"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+true: "સાચું"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+undef: "અવ્યાખ્યાયિત"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+unless: "સિવાય કે"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+until: "ત્યાં સુધી"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+when: "ક્યારે(ત્યારે)"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+while: "જ્યારે"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+yield: "યિલ્ડ(ઉપજ)"
+  # ✅ @136tejas
+  # ✅ @aadii0408
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/he.yml
+++ b/locale/he.yml
@@ -1,0 +1,2557 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "he"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "הערה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  INFO: "מידע"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  IDEA: "רעיון"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  DEBUG: "מציאת_באגים"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ❓ @michalirak "דיבוג"
+  REMOVE: "הסר"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  OPTIMIZE: ""
+    # ❓ @Adarwall
+    # ❓ @Gal-Gilor "ייעול"
+    # ❓ @tomerpacific "הפוך_ליעיל"
+    # ✅ @michalirak "ייעול" or "אופטימיזציה"
+  REVIEW: ""
+    # ❓ @Adarwall
+    # ❓ @Gal-Gilor "סקירה"
+    # ❓ @tomerpacific "לבצע_סקירה"
+    # ❓ @michalirak "סקירה"
+  HACK: "האק"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor "פריצה או פרץ?"
+    # ❓ @tomerpacific "פתרון_פרוץ"
+    # ❓ @michalirak "האק" or "אלתור"
+  UNDONE: "שחזר"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ❓ @tomerpacific "מצריך_עבודה"
+    # ❓ @tomerpacific "משוחזר"
+  TODO: ""
+    # ❓ @Adarwall
+    # ❓ @Gal-Gilor "לעשות"
+    # ❓ @tomerpacific "צריך_לעשות"
+    # ❓ @michalirak "לעשות"
+  REFACTOR: "לעשות_מחדש"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor "לשפר"
+    # ❓ @tomerpacific "מצריך_שיפור"
+    # ❓ @michalirak "שיפוץ"
+  DEPRECATED: "הוצא_משימוש"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  TASK: "מטלה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  CHGME: ""
+    # ❓ @Adarwall
+    # 🤔 @Gal-Gilor "Requires elaboration on what this word does"
+    # ❓ @tomerpacific "שנה_אותי"
+    # ❓ @michalirak "שנה_אותי"
+  NOTREACHED: ""
+    # ❓ @Adarwall
+    # 🤔 @Gal-Gilor "Requires elaboration on what this word does"
+    # ❓ @tomerpacific "לא_הושג"
+    # ❓ @michalirak "לא_הושג"
+  WTF: "וואט_דה_פאק"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ❓ @tomerpacific "מה_לעזאזל"
+    # ❓ @michalirak "מה_לעזאזל"
+  BUG: "באג"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  ERROR: "שגיאה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  OMG: "או_מיי_גאד"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor "אלוהים_אדירים"
+    # ❓ @tomerpacific "אלוהים_ישמור"
+    # ✅ @michalirak
+  ERR: "שגיאה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  OMFGRLY: ""
+    # ❓ @Adarwall
+    # 🤔 @Gal-Gilor "OMG REALLY isn't used much. Same as OMG (אלוהים_אדירים)"
+    # ❓ @tomerpacific "אני_לא_מאמין_למראה_עיניי"
+    # 🤔 @michalirak "נו באמת can be used but has a passive aggressive tone, otherwise agree with @Gal-Gilor"
+  WARNING: "אזהרה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  WARN: "אזהרה"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor "להזהיר"
+    # ❓ @tomerpacific "להזהיר"
+    # ❓ @michalirak "להזהיר"
+  BROKEN: "שבור"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: "ייבא"
+    # ✅ @Adarwall
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: "פרטי"
+    # ✅ @Adarwall
+  public: "ציבורי"
+    # ✅ @Adarwall
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: "כל_עוד"
+  # ✅ @Adarwall
+for: "לכל"
+  # ✅ @Adarwall
+if: "אם" # (part of if-else statement)
+  # ✅ @Adarwall
+else: "אחרת" # (part of if-else statement)
+  # ✅ @Adarwall
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: "החזר"
+  # ✅ @Adarwall
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: "כלום"
+  # ✅ @Adarwall
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: "אחרת_אז"
+  # ✅ @Adarwall
+else: "אחרת"
+  # ✅ @Adarwall
+esac: ""
+fi: ""
+for: "לכל"
+  # ✅ @Adarwall
+function: ""
+if: "אם"
+  # ✅ @Adarwall
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: "ממשי"
+  # ✅ @Adarwall
+int: "שלם"
+  # ✅ @Adarwall
+struct: ""
+break: ""
+else: "אחרת"
+  # ✅ @Adarwall
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: "החזר"
+  # ✅ @Adarwall
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: "לכל"
+  # ✅ @Adarwall
+signed: ""
+void: "ריק"
+  # ✅ @Adarwall
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: "אם"
+  # ✅ @Adarwall
+static: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: "אחרת"
+  # ✅ @Adarwall
+#endif: ""
+#error: ""
+#if: "אם"
+  # ✅ @Adarwall
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: "תו"
+  # ✅ @Adarwall
+char16_t: ""
+char32_t: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: "אחרת"
+  # ✅ @Adarwall
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: "שקר"
+  # ✅ @Adarwall
+final: ""
+float: ""
+for: "לכל"
+  # ✅ @Adarwall
+friend: ""
+goto: ""
+if: "אם"
+  # ✅ @Adarwall
+inline: ""
+int: "שלם"
+  # ✅ @Adarwall
+import: "ייבא"
+  # ✅ @Adarwall
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: "חדש"
+  # ✅ @Adarwall
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: "פרטי"
+  # ✅ @Adarwall
+protected: ""
+public: "ציבורי"
+  # ✅ @Adarwall
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: "החזר"
+  # ✅ @Adarwall
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: "זה"
+  # ✅ @Adarwall
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: "אמת"
+  # ✅ @Adarwall
+try: "נסה"
+  # ✅ @Adarwall
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: "ריק"
+  # ✅ @Adarwall
+volatile: ""
+wchar_t: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: "בסנכרון"
+  # ✅ @Adarwall
+await: "המתן"
+  # ✅ @Adarwall
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: "תפוס"
+  # ✅ @Adarwall
+char: "תו"
+  # ✅ @Adarwall
+checked: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: "ממשי"
+  # ✅ @Adarwall
+dynamic: ""
+else: "אחרת"
+  # ✅ @Adarwall
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: "שקר"
+  # ✅ @Adarwall
+finally: ""
+fixed: ""
+float: ""
+for: "לכל"
+  # ✅ @Adarwall
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: "אם"
+  # ✅ @Adarwall
+implicit: ""
+in: ""
+int: "שלם"
+  # ✅ @Adarwall
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: "חדש"
+  # ✅ @Adarwall
+null: "כלום"
+  # ✅ @Adarwall
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: "פרטי"
+  # ✅ @Adarwall
+protected: ""
+public: "ציבורי"
+  # ✅ @Adarwall
+readonly: ""
+ref: ""
+remove: ""
+return: "החזר"
+  # ✅ @Adarwall
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: "זה"
+  # ✅ @Adarwall
+throw: ""
+true: "אמת"
+  # ✅ @Adarwall
+try: ""
+typeof: "מסוג"
+  # ✅ @Adarwall
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "יישור-תוכן" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+  # ✅ @Adarwall
+align-items: "יישור-פריטים" #	Specifies the alignment for items inside a flexible container
+  # ✅ @Adarwall
+align-self: "יישור-עצמי" #	Specifies the alignment for selected items inside a flexible container
+  # ✅ @Adarwall
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "אנימציה" #	A shorthand property for all the animation-* properties
+  # ✅ @Adarwall
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "אנימציה-כיוון" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+  # ✅ @Adarwall
+animation-duration: "אנימציה-משך-זמן" #	Specifies how long an animation should take to complete one cycle
+  # ✅ @Adarwall
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "אנימציה-שם" #	Specifies a name for the @keyframes animation
+  # ✅ @Adarwall
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "רקע" #	A shorthand property for all the background-* properties
+  # ✅ @Adarwall
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "רקע-צבע" #	Specifies the background color of an element
+  # ✅ @Adarwall
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "רקע-גודל" #	Specifies the size of the background images
+  # ✅ @Adarwall
+border: "מסגרת" #	A shorthand property for border-width, border-style and border-color
+  # ✅ @Adarwall
+border-bottom: "מסגרת-תחתית" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+  # ✅ @Adarwall
+border-color: "מסגרת-צבע" #	Sets the color of the bottom border
+  # ✅ @Adarwall
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "עובי-מסגרת" #	Sets the width of the left border
+  # ✅ @Adarwall
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "תחתית" #	Sets the elements position, from the bottom of its parent element
+  # ✅ @Adarwall
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "צל" #	Attaches one or more shadows to an element
+  # ✅ @Adarwall
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "צבע" #	Sets the color of text
+  # ✅ @Adarwall
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "תצוגה" #	Specifies how a certain HTML element should be displayed
+  # ✅ @Adarwall
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "פונט" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+  # ✅ @Adarwall
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "פונט-משפחה" #	Specifies the font family for text
+  # ✅ @Adarwall
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "פונט-גודל" #	Specifies the font size of text
+  # ✅ @Adarwall
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "פונט-משקל" #	Specifies the weight of a font
+  # ✅ @Adarwall
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "גובה" #	Sets the height of an element
+  # ✅ @Adarwall
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "ייבא" #	Allows you to import a style sheet into another style sheet
+  # ✅ @Adarwall
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "שמאל" #	Specifies the left position of a positioned element
+  # ✅ @Adarwall
+letter-spacing: "ריווח-אותיות" #	Increases or decreases the space between characters in a text
+  # ✅ @Adarwall
+line-break: "שבירת-שורה" #	Specifies how/if to break lines
+  # ✅ @Adarwall
+line-height: "גובה-שורה" #	Sets the line height
+  # ✅ @Adarwall
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "ריווח-חוץ" #	Sets all the margin properties in one declaration
+  # ✅ @Adarwall
+margin-bottom: "ריווח-חוץ-למטה" #	Sets the bottom margin of an element
+  # ✅ @Adarwall
+margin-left: "ריווח-חוץ-שמאל" #	Sets the left margin of an element
+  # ✅ @Adarwall
+margin-right: "ריווח-חוץ-ימין" #	Sets the right margin of an element
+  # ✅ @Adarwall
+margin-top: "ריווח-חוץ-למעלה" #	Sets the top margin of an element
+  # ✅ @Adarwall
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "שקיפות" #	Sets the opacity level for an element
+  # ✅ @Adarwall
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "ריווח-פנים" #	A shorthand property for all the padding-* properties
+  # ✅ @Adarwall
+padding-bottom: "ריווח-פנים-למטה" #	Sets the bottom padding of an element
+  # ✅ @Adarwall
+padding-left: "ריווח-פנים-שמאל" #	Sets the left padding of an element
+  # ✅ @Adarwall
+padding-right: "ריווח-פנים-ימין" #	Sets the right padding of an element
+  # ✅ @Adarwall
+padding-top: "ריווח-פנים-למעלה" #	Sets the top padding of an element
+  # ✅ @Adarwall
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "שנה-גודל" #	Defines if (and how) an element is resizable by the user
+  # ✅ @Adarwall
+right: "ימין" #	Specifies the right position of a positioned element
+  # ✅ @Adarwall
+scroll-behavior: "אופן-גלילה" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+  # ✅ @Adarwall
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "מלל-כיוון" #	Specifies the horizontal alignment of text
+  # ✅ @Adarwall
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "מלל-צבע" #	Specifies the color of the text-decoration
+  # ✅ @Adarwall
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "למעלה" #: "" #	Specifies the top position of a positioned element
+  # ✅ @Adarwall
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "רוחב" #	Sets the width of an element
+  # ✅ @Adarwall
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "שכבה" #	Sets the stack order of a positioned element
+  # ✅ @Adarwall
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: "אחרת"
+  # ✅ @Adarwall
+goto: ""
+package: "חבילה"
+  # ✅ @Adarwall
+switch: ""
+const: ""
+fallthrough: ""
+if: "אם"
+  # ✅ @Adarwall
+range: ""
+type: ""
+continue: ""
+for: "לכל"
+  # ✅ @Adarwall
+import: "ייבא"
+  # ✅ @Adarwall
+return: "החזר"
+  # ✅ @Adarwall
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: "אם"
+  # ✅ @Adarwall
+then: ""
+else: "אחרת"
+  # ✅ @Adarwall
+import: "ייבא"
+  # ✅ @Adarwall
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "סוג_מסמך" #	Defines the document type
+  # ✅ @Adarwall
+a: "קישור" #	Defines a hyperlink
+  # ✅ @Adarwall
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "מודגש" #	Defines bold text
+  # ✅ @Adarwall
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "יישור" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+  # ✅ @Adarwall
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "גוף" #	Defines the document's body
+  # ✅ @Adarwall
+br: "הפסקה" #	Defines a single line break
+  # ✅ @Adarwall
+button: "כפתור" #	Defines a clickable button
+  # ✅ @Adarwall
+canvas: "קאנבס" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+  # ✅ @Adarwall
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "חלקה" #	Defines a section in a document
+  # ✅ @Adarwall
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "פונט" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+  # ✅ @Adarwall
+footer: "תחתית" #	Defines a footer for a document or section
+  # ✅ @Adarwall
+form: "טופס" #	Defines an HTML form for user input
+  # ✅ @Adarwall
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "כותרת" # to <h6>	Defines HTML headings
+  # ✅ @Adarwall
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "html" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "תמונה" #	Defines an image
+  # ✅ @Adarwall
+input: "קלט" #	Defines an input control
+  # ✅ @Adarwall
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "רשימה" #	Defines a list item
+  # ✅ @Adarwall
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "אובייקט" #	Defines an embedded object
+  # ✅ @Adarwall
+ol: "רשימה_סדורה" #	Defines an ordered list
+  # ✅ @Adarwall
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "פסקה" #	Defines a paragraph
+  # ✅ @Adarwall
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "מקטע" #	Defines a section in a document
+  # ✅ @Adarwall
+select: "תפריט_יורד" #	Defines a drop-down list
+  # ✅ @Adarwall
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "חשוב" #	Defines important text
+  # ✅ @Adarwall
+style: "סטייל" #	Defines style information for a document
+  # ✅ @Adarwall
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "טבלה" #	Defines a table
+  # ✅ @Adarwall
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "קלט_שורות" #	Defines a multiline input control (text area)
+  # ✅ @Adarwall
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "כותרת" #	Defines a title for the document
+  # ✅ @Adarwall
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "משתנה" #	Defines a variable
+  # ✅ @Adarwall
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: "לכל"
+  # ✅ @Adarwall
+new: "חדש"
+  # ✅ @Adarwall
+switch: "סנן"
+  # ✅ @Adarwall
+assert: ""
+default: "ברירת_מחדל"
+  # ✅ @Adarwall
+goto: ""
+package: "חבילה"
+  # ✅ @Adarwall
+synchronized: ""
+boolean: ""
+do: ""
+if: "אם"
+  # ✅ @Adarwall
+private: "פרטי"
+  # ✅ @Adarwall
+this: "זה"
+  # ✅ @Adarwall
+break: "לשבור"
+  # ✅ @Adarwall
+double: "ממשי"
+  # ✅ @Adarwall
+implements: ""
+protected: ""
+throw: "זרוק"
+  # ✅ @Adarwall
+byte: ""
+else: "אחרת"
+  # ✅ @Adarwall
+import: "ייבא"
+  # ✅ @Adarwall
+public: "ציבורי"
+  # ✅ @Adarwall
+throws: ""
+case: "מקרה"
+  # ✅ @Adarwall
+enum: ""
+instanceof: ""
+return: "החזר"
+  # ✅ @Adarwall
+transient: ""
+catch: "תפוס"
+  # ✅ @Adarwall
+extends: ""
+int: "שלם"
+  # ✅ @Adarwall
+short: "שלם_קצר"
+  # ✅ @Adarwall
+try: "נסה"
+  # ✅ @Adarwall
+char: "תו"
+  # ✅ @Adarwall
+final: "קבוע"
+  # ✅ @Adarwall
+interface: ""
+static: "סטטי"
+  # ✅ @Adarwall
+void: "ריק"
+  # ✅ @Adarwall
+class: "מחלקה"
+  # ✅ @Adarwall
+finally: "לבסוף"
+  # ✅ @Adarwall
+long: "שלם_ממש_גדול"
+  # ✅ @Adarwall
+strictfp: ""
+volatile: ""
+const: "קבוע"
+  # ✅ @Adarwall
+float: "ממשי_גדול"
+  # ✅ @Adarwall
+native: ""
+super: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+_: "_" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "ארגומנטים"
+await: "המתן"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+break: "לשבור"
+  # ✅ @Adarwall
+  # ❓ @tomerpacific - Should be "שבור" as this is the action taken
+case: "מקרה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+catch: "תפוס"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+class: "מחלקה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+const: "קבוע"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+continue: "המשך"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+debugger: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "דיבאגר"
+default: "ברירת_מחדל"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+delete: "מחק"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+do: "תעשה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+else: "אחרת"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+enum: ""
+  # 👀 @Adarwall
+  # 🤔 @tomerpacific - There are no enums in JavaScript
+eval: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "שערך"
+export: "יצוא"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+extends: "הרחב"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+false: "שקר"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+finally: "לבסוף"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+for: "לכל"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+from: "מ"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+function: "פעולה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+if: "אם"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+implements: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "מממש"
+import: "ייבוא"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+in: "ב"
+  # ✅ @Adarwall
+  # ❓ @tomerpacific - Consider using "בתוך"
+instanceof: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "מופע_של"
+interface: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "ממשק"
+let: "משתנה"
+  # ✅ @Adarwall
+  # ❓ @tomerpacific - Let is used to define a blocked scoped variable so maybe use the term "משתנה_לוקאלי"?
+new: "חדש"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+null: "כלום"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+package: "חבילה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+private: "פרטי"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+protected: "מוגן"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+public: "ציבורי"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+return: "החזר"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+static: "סטטי"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+super: ""
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "קריאה_למחלקת_אם"
+switch: "סנן"
+  # ✅ @Adarwall
+  # ❓ @tomerpacific - Switch statements are used to break down values of a variable so the current term is less fitting in my opinion. Maybe consider "בורר_מקרים"?
+this: "זה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+throw: "זרוק"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+true: "אמת"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+try: "נסה"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+typeof: "פורמט"
+  # ✅ @Adarwall
+  # ❓ @tomerpacific - Typeof is used to find the type of a variable so I suggest using "סוג_של"
+var: "משתנה_כללי"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+void: "ריק"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+while: "כל_עוד"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+with: "עם"
+  # ✅ @Adarwall
+  # ✅ @tomerpacific
+yield: "השהה"
+  # 👀 @Adarwall
+  # ✅ @tomerpacific "השהה"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+if: "אם"
+  # ✅ @Adarwall
+for: "לכל"
+  # ✅ @Adarwall
+try: ""
+return: "החזר"
+  # ✅ @Adarwall
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: "ייבא"
+  # ✅ @Adarwall
+export: ""
+importall: ""
+end: ""
+else: "אחרת"
+  # ✅ @Adarwall
+catch: ""
+finally: ""
+true: "אמת"
+  # ✅ @Adarwall
+false: "שקר"
+  # ✅ @Adarwall
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "מחלקה" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+  # ✅ @Adarwall
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "חבילה" # This symbol is meant to be package-private.
+  # ✅ @Adarwall
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "פרטי" #This symbol is meant to be private.
+  # ✅ @Adarwall
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "ציבורי" #This symbol is meant to be public.
+  # ✅ @Adarwall
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "זה" #What does the 'this' keyword refer to here?
+  # ✅ @Adarwall
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "מחלקה" #
+  # ✅ @Adarwall
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "אחרת" #
+  # ✅ @Adarwall
+end: "" #
+exception: "" #
+external: "" #
+false: "שקר" #
+  # ✅ @Adarwall
+for: "לכל" #
+  # ✅ @Adarwall
+fun: "" #
+function: "" #
+functor: "" #
+if: "אם" #
+  # ✅ @Adarwall
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "חדש" #
+  # ✅ @Adarwall
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "פרטי" #
+  # ✅ @Adarwall
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "אמת" #
+  # ✅ @Adarwall
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "כל_עוד" #
+  # ✅ @Adarwall
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: "מערך"
+  # ✅ @Adarwall
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: "אחרת"
+  # ✅ @Adarwall
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: "כל_עוד"
+  # ✅ @Adarwall
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: "לכל"
+  # ✅ @Adarwall
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: "אם"
+  # ✅ @Adarwall
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: "חדש"
+  # ✅ @Adarwall
+or: ""
+print: ""
+private: "פרטי"
+  # ✅ @Adarwall
+protected: ""
+public: "ציבורי"
+  # ✅ @Adarwall
+require: ""
+require_once: ""
+return: "החזר"
+  # ✅ @Adarwall
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "שקר"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  None: "כלום"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor "ריק" Python's "None" is equivalent to other language's null
+    # ❓ @tomerpacific None is not equivalent to null of other languages. I think the current translation is fitting.
+    # ✅ @michalirak
+  True: "אמת"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  and: "ו"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor Although 100% correct. I'm hesistant to use a single character
+    # ❓ @tomerpacific Maybe should be renamed to "וגם"
+    # ❓ @michalirak Agree with @tomerpacific
+  as: "כ"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor Although 100% correct. I'm hesistant to use a single character
+    # ✅ @tomerpacific
+    # ✅ @michalirak Agree with @Gal-Gilor
+  assert: "הנח"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor In Python, I could aruge I can replace "assert" with "insist" I suggest "לדרוש  or להתעקש"
+    # ❓ @tomerpacific When assert is used, it is to evaluate a certain condition. Therefore, I believe a better translation would be "בחן".
+    # ❓ @michalirak "טען"
+  async: "בסנכרון"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor 'אסינכרוני' The opposite of Sync
+    # ❓ @tomerpacific Should be renamed to "אסינכרוני"
+    # ❓ @michalirak I agree with @tomerpacific
+  await: "המתן"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  break: "לשבור"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ❓ @tomerpacific Should be "שבור"
+    # ❓ @michalirak I agree with @tomerpacific
+  class: "מחלקה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor I agree. However, thoughts on "אובייקט" (I understand they are not the same)?
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  continue: "המשך"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  def: "פעולה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ❓ @tomerpacific This keyword means definition so the translation should be "הגדר"
+    # ❓ @michalirak I agree with @tomerpacific
+  del: "מחק"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  elif: "אחרת_אז"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  else: "אחרת"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  except: "בשגיאה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ❓ @tomerpacific This marks and exception, so it should be "חריגה"
+    # ❓ @michalirak The current translation matches the pythonic function while @tomerpacific 's translation matches the word's meaning better.
+  finally: "לבסוף"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  for: "לכל"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ❓ @michalirak "עבור"
+  from: "מ"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor Although 100% correct. I'm hesistant to use a single character
+    #    @tomerpacific
+    # ❓ @michalirak Once again I agree with @Gal-Gilor
+  global: "גלובלי"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  if: "אם"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  import: "ייבא"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  in: "ב"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor although 100% correct. I'm hesistant to use a single character. how about "בתוך"
+    # ❓ @tomerpacific I support "בתוך"
+    # ❓ @michalirak Once again I agree with @Gal-Gilor, and support the suggested solution of "בתוך"
+  is: "הוא"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  lambda: "פעולונת"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor Clever!
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  nonlocal: "לא_מקומי"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  not: "לא"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ❓ @michalirak "אינו"
+  or: "או"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  pass: "קוד_עתידי"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor Since "pass" is a null statement, how about "הצהרת_בטל"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "עבור"
+  raise: "העלה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  return: "החזר"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  try: "נסה"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  while: "כל_עוד"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ❓ @michalirak "בעוד" for a neat one word translation
+  with: "עם"
+    # ✅ @Adarwall
+    # ✅ @Gal-Gilor
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  yield: "הוצא"
+    # ✅ @Adarwall
+    # ❓ @Gal-Gilor How about "חולל איטרטור"
+    # ❓ @tomerpacific How about "חולל גנרטור"
+    # ❓ @michalirak "הנב"
+
+# << Built-In Functions >>
+
+  abs: "ערך_מוחלט"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  all: "הכל"
+    # ✅ @Adarwall
+    # ❓ @michalirak "כל"
+  any: "כל_ערך"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  ascii: "אסקי"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  bin: "בינארי"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  bool: "בוליאני"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  breakpoint: "נקודת_שבירה"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  bytearray: "מערך_בייטים"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  bytes: "בייטים"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  callable: "ניתן_לקריאה"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  chr: "תו"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  classmethod: "מתודת_מחלקה"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  compile: "עבד"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "קמפל" or "הדר"
+  complex: "מורכב"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  delattr: "מחק_תכונה"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  dict: "מילון"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  dir: "תיקיה"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  divmod: "חלוקה"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "חלק"
+  enumerate: "למנות"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "מנה"
+  eval: "לשערך"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "הערך"
+  exec: "לבצע"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "בצע"
+  filter: "סנן"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  float: "ממשי"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  format: "ערוך_לתבנית"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  frozenset: "מערכת_בלתי_ניתנת_לשינוי"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "מערכת_קפואה"
+  getattr: "השג_ערך"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "השג_תכונה" to match delattr
+  globals: "גלובאלים"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  hasattr: "בעל_תכונה"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  hash: "בליל"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "גיבוב"
+  help: "עזרה"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  hex: "הקסדצימלי"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  id: "מזהה"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  input: "קלט"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  int: "שלם"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  isinstance: "האם_סוג_של"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "האם_מופע" going by the traditional translation of instance
+  issubclass: "מחלקה"
+    # ✅ @Adarwall
+    # ❓ @michalirak "האם_תת_מחלקה" the current translation approved by @Adarwall is literally <class>, which is not the same as <issubclass>
+  iter: "איטרטור"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  len: "אורך"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  list: "רשימה"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  locals: "טבלת_ערכים_מקומיים"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "מקומיים" following the conventions set by <globals>
+  map: "למפות"
+    # ✅ @Adarwall
+    # ❓ @michalirak "מפה"
+  max: "מקסימום"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  memoryview: "אובייקט_תצוגת_זיכרון"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "תצוגת_זיכרון" ommiting the word for object, which is not used in any other object-word here
+  min: "מינימום"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  next: "הבא"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  object: "אובייקט"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  oct: "אוקטלי"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  open: "פתח"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  ord: "ערך_תו_יוניקוד"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "אורדינלי" following the translations for <oct> <hex> and so on
+  pow: "חזקה"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  print: "הדפס"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  property: "תכונה"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "מאפיין" so that it differs from <attr>
+  range: "טווח"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  repr: "ייצוג_להדפסה"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "ייצוג"
+  reversed: "מהופך"
+    # ✅ @Adarwall
+    # ❓ @michalirak "הפוך"
+  round: "עיגול"
+    # ✅ @Adarwall
+    # ❓ @michalirak "עגל"
+  set: "הגדר"
+    # ✅ @Adarwall
+    # ❓ @michalirak "קבוצה" This is the programming translation. The current translation means "define" which is clearly not meant here
+  setattr: "ערוך_תכונה"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  slice: "חתוך"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  sorted: "ממויין"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  staticmethod: "מתודה_סטטית"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  str: "מחרוזת"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  sum: "סכום"
+    # ✅ @Adarwall
+    # ✅ @michalirak
+  super: "מחלקת אם"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "מחלקת_אם" Following the no-spaces convention used
+  tuple: "צמד"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  type: "סוג"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  vars: "תכונת_מילון"
+    # ✅ @tomerpacific
+    # ❓ @michalirak "הפוך_למילון"
+  zip: "לקבץ"
+    # ✅ @tomerpacific
+    # ✅ @michalirak
+  __import__: "__ייבוא__"
+    # ✅ @Adarwall
+    # ❓ @michalirak "__יבא__" following the translation for <import>
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "לכל"
+  # ✅ @Adarwall
+@foreach: "" #
+@if: "אם" #
+@else: "אחרת" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "כל_עוד"
+  # ✅ @Adarwall
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+def: ""
+defined?: ""
+do: ""
+else: "אחרת"
+  # ✅ @Adarwall
+elsif: ""
+end: ""
+ensure: ""
+false: "שקר"
+  # ✅ @Adarwall
+for: "לכל"
+  # ✅ @Adarwall
+if: "אם"
+  # ✅ @Adarwall
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: "החזר"
+  # ✅ @Adarwall
+self: ""
+super: ""
+then: ""
+true: "אמת"
+  # ✅ @Adarwall
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: "אחרת"
+  # ✅ @Adarwall
+enum: ""
+extern: ""
+false: "שקר"
+  # ✅ @Adarwall
+final: ""
+fn: ""
+for: "לכל"
+  # ✅ @Adarwall
+if: "אם"
+  # ✅ @Adarwall
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: "החזר"
+  # ✅ @Adarwall
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: "אמת"
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+def: ""
+do: ""
+else: "אחרת"
+  # ✅ @Adarwall
+extends: ""
+false: "שקר"
+  # ✅ @Adarwall
+final: ""
+finally: ""
+for: "לכל"
+  # ✅ @Adarwall
+forSome: ""
+if: "אם"
+  # ✅ @Adarwall
+implicit: ""
+import: "ייבא"
+  # ✅ @Adarwall
+lazy: ""
+macro: ""
+match: ""
+new: "חדש"
+  # ✅ @Adarwall
+null: "כלום"
+  # ✅ @Adarwall
+object: ""
+override: ""
+package: "חבילה"
+  # ✅ @Adarwall
+private: "פרטי"
+  # ✅ @Adarwall
+protected: ""
+return: "החזר"
+  # ✅ @Adarwall
+sealed: ""
+super: ""
+this: "זה"
+  # ✅ @Adarwall
+throw: ""
+trait: ""
+try: ""
+true: "אמת"
+  # ✅ @Adarwall
+type: ""
+val: ""
+var: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+deinit: ""
+enum: ""
+extension: ""
+func: "פעולה"
+  # ✅ @Adarwall
+import: "ייבא"
+  # ✅ @Adarwall
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: "פרטי"
+  # ✅ @Adarwall
+protocol: ""
+public: "ציבורי"
+  # ✅ @Adarwall
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: "אחרת"
+  # ✅ @Adarwall
+fallthrough: ""
+for: "לכל"
+  # ✅ @Adarwall
+guard: ""
+if: "אם"
+  # ✅ @Adarwall
+in: ""
+repeat: ""
+return: "החזר"
+  # ✅ @Adarwall
+switch: ""
+where: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+as: ""
+catch: ""
+dynamicType: ""
+false: "שקר"
+  # ✅ @Adarwall
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: "אמת"
+  # ✅ @Adarwall
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: "אחרת"
+  # ✅ @Adarwall
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: "אם"
+  # ✅ @Adarwall
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: "מחלקה"
+  # ✅ @Adarwall
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: "אחרת"
+  # ✅ @Adarwall
+enum: ""
+export: ""
+extends: ""
+false: "שקר"
+  # ✅ @Adarwall
+finally: ""
+for: "לכל"
+  # ✅ @Adarwall
+function: ""
+if: "אם"
+  # ✅ @Adarwall
+import: "ייבא"
+  # ✅ @Adarwall
+in: ""
+instanceof: ""
+new: "חדש"
+  # ✅ @Adarwall
+null: "כלום"
+  # ✅ @Adarwall
+return: "החזר"
+  # ✅ @Adarwall
+super: ""
+switch: ""
+this: "זה"
+  # ✅ @Adarwall
+throw: ""
+true: "אמת"
+  # ✅ @Adarwall
+try: ""
+typeof: "מסוג"
+  # ✅ @Adarwall
+var: ""
+void: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: "חבילה"
+  # ✅ @Adarwall
+private: "פרטי"
+  # ✅ @Adarwall
+protected: ""
+public: "ציבורי"
+  # ✅ @Adarwall
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: "אחרת"
+  # ✅ @Adarwall
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: "לכל"
+  # ✅ @Adarwall
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: "אם"
+  # ✅ @Adarwall
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: "כל_עוד"
+  # ✅ @Adarwall
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/hi.yml
+++ b/locale/hi.yml
@@ -1,0 +1,3278 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "hi"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "टिप्पणी"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  INFO: "जानकारी"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  IDEA: "विचार"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  DEBUG: "दोषमार्जन"
+    # ❓ @sshiv5768 "डीबग करें"
+    # ❓ @bhaveshgoyal182 "डीबग"
+    # ❓ @aadii0408 "डीबग करें"
+  REMOVE: "हटाना"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  OPTIMIZE: "अनुकूलन"
+    # ❓ @sshiv5768 "सुधारना"
+    # ❓ @bhaveshgoyal182 "सुधारना"
+    # ❓ @aadii0408 "सुधारना"
+  REVIEW: "समीक्षा"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  HACK: "हैक"
+    # ✅ @sshiv5768
+    # ❓ @bhaveshgoyal182 "आसान तरीका"
+    # ✅ @aadii0408
+  UNDONE: "पूर्ववत"
+    # ❓ @sshiv5768 "असंपादित"
+    # ❓ @bhaveshgoyal182 "न किया हुआ"
+    # ✅ @aadii0408 -"नष्ट कर दिया"
+  TODO: "करने के लिए"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  REFACTOR: "रेफेक्टर"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  DEPRECATED: "बहिष्कृत किया गया"
+    # ❓ @sshiv5768 "बहिष्कृत करना"
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  TASK: "कार्य"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  CHGME: "CHGME"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  NOTREACHED: "नहीं पहुँचा"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  WTF: "WTF"
+    # ✅ @sshiv5768 Original word looks more programmic
+    # ❓ @bhaveshgoyal182 "बेहूदा"
+    # ❓ @aadii0408 "क्या बकवास है"
+  BUG: "प्रोग्राम में त्रुटि, दोष"
+    # ✅ @sshiv5768 "प्रोग्राम में त्रुटि, दोष"
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  ERROR: "त्रुटि"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  OMG: "OMG"
+    # ✅ @sshiv5768 Original word suits way better rather than full form tranlation of OMG word
+    # ❓ @bhaveshgoyal182 "हे भगवान"
+    # ✅ @aadii0408 - Original word suits better
+  ERR: "ERR"
+    # ❓ @sshiv5768 "त्रुटि"
+    # ❓ @bhaveshgoyal182 "त्रुटि"
+    # ❓ @aadii0408 "त्रुटि"
+  OMFGRLY: "OMFGRLY"
+    # ✅ @sshiv5768 Original word looks more programmic
+    # 🤔 @bhaveshgoyal182
+    # 🤔 @aadii0408
+  WARNING: "चेतावनी"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  WARN: "चेतावनी देना"
+    # ✅ @sshiv5768
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+  BROKEN: "टूटा हुआ"
+    # ❓ @sshiv5768 "टूटा"
+    # ✅ @bhaveshgoyal182
+    # ✅ @aadii0408
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: "सार"
+    # ✅ @bhaveshgoyal182
+  codata: "दत्त-सामग्री"
+    # ✅ @bhaveshgoyal182
+  coinductive: "सहगामी"
+    # ✅ @bhaveshgoyal182
+  constructor: "निर्माता"
+    # ✅ @bhaveshgoyal182
+  data: "आंकड़े"
+    # ✅ @bhaveshgoyal182
+  do: "करना"
+    # ✅ @bhaveshgoyal182
+  eta-equality: "ईटा-समानता"
+    # ✅ @bhaveshgoyal182
+  field: "क्षेत्र"
+    # ✅ @bhaveshgoyal182
+  forall: "सबके लिए"
+    # ✅ @bhaveshgoyal182
+  hiding: "छिपाना"
+    # ✅ @bhaveshgoyal182
+  import: "आयात"
+    # ✅ @bhaveshgoyal182
+  in: "अंदर"
+    # ✅ @bhaveshgoyal182
+  inductive: "अधिष्ठापन का"
+    # ✅ @bhaveshgoyal182
+  infix: "इन्फ़िक्स"
+    # ✅ @bhaveshgoyal182
+  infixl: ""
+    # 👀 @bhaveshgoyal182
+  infixr: ""
+    # 👀 @bhaveshgoyal182
+  instance: "दृष्टांत"
+    # ✅ @bhaveshgoyal182
+  let: "सोचना"
+    # ✅ @bhaveshgoyal182
+  macro: "मैक्रो"
+    # ✅ @bhaveshgoyal182
+  module: "मापांक"
+    # ✅ @bhaveshgoyal182
+  mutual: "आपस का"
+    # ✅ @bhaveshgoyal182
+  no-eta-equality: ""
+    # 👀 @bhaveshgoyal182
+  open: "खुला"
+    # ✅ @bhaveshgoyal182
+  overlap: "अधिव्यापन"
+    # ✅ @bhaveshgoyal182
+  pattern: "प्रतिरूप"
+    # ✅ @bhaveshgoyal182
+  postulate: "मांगना"
+    # ✅ @bhaveshgoyal182
+  primitive: "प्राचीन"
+    # ✅ @bhaveshgoyal182
+  private: "निजी"
+    # ✅ @bhaveshgoyal182
+  public: "सार्वजनिक"
+    # ✅ @bhaveshgoyal182
+  quote: "उद्धरण"
+    # ✅ @bhaveshgoyal182
+  quoteContext: ""
+    # 👀 @bhaveshgoyal182
+  quoteGoal: ""
+    # 👀 @bhaveshgoyal182
+  quoteTerm: ""
+    # 👀 @bhaveshgoyal182
+  record: "अभिलेख"
+    # ✅ @bhaveshgoyal182
+  renaming: "नाम बदलने"
+    # ✅ @bhaveshgoyal182
+  rewrite: "पुनर्लेखन"
+    # ✅ @bhaveshgoyal182
+  Set: ""
+    # 👀 @bhaveshgoyal182 can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "वाक्यविन्यास"
+    # ✅ @bhaveshgoyal182
+  tactic: "रणनीति"
+    # ✅ @bhaveshgoyal182
+  unquote: ""
+    # 👀 @bhaveshgoyal182
+  unquoteDecl: ""
+    # 👀 @bhaveshgoyal182
+  unquoteDef: ""
+    # 👀 @bhaveshgoyal182
+  using: "का उपयोग करते हुए"
+    # ✅ @bhaveshgoyal182
+  where: "कहां"
+    # ✅ @bhaveshgoyal182
+  with: "साथ"
+    # ✅ @bhaveshgoyal182
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "करना"
+  # ✅ @sshiv5768 (part of do-while statement)
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408 ( in d0-while stat)
+while: "जबकि"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+for: "के लिये"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+if: "अगर"
+  # ✅ @sshiv5768 (part of if-else statement)
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+else: "और"
+  # ✅ @sshiv5768 (part of if-else statement)
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+switch: "बदलना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+break: "विराम"
+  # ✅ @sshiv5768 (part of the switch statement or for/while statements)
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+case: "स्थिति"
+  # ✅ @sshiv5768 (part of the switch statement)
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+continue: "जारी रखें"
+  # ✅ @sshiv5768 (part of for/while statements)
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+default: "डिफ़ॉल्ट"
+  # ✅ @sshiv5768 (part of switch statement)
+  # ❓ @bhaveshgoyal182 "अभाव"
+  # ❓ @aadii0408 (i think this should be more convenient "अप्राप्तिा"
+function: "कार्य"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+procedure: "प्रक्रिया"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+return: "वापसी"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+local: "स्थानीय"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+global: "वैश्विक"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+static: "स्थिर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+typeof: "प्रकार का"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+NOT: "नहीं"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+AND: "तथा"
+  # ✅ @sshiv5768
+  # ❓ @bhaveshgoyal182 "और"
+  # ✅ @aadii0408
+OR: "या"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+Null: "अमान्य"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @aadii0408
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "मामला"
+  # ❓ @sshiv5768 "स्थिति"
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+do: "करना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+done: "किया हुआ"
+  # ❓ @sshiv5768 "पूर्ण"
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+elif: "और अगर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+else: "और"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ❓ @179priyasoni "अन्यथा" is better
+esac: "esac"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # 👀 @179priyasoni
+fi: "fi"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # 👀 @179priyasoni
+for: "के लिये"
+  # ❓ @sshiv5768 Hindi translation is perfect but for programming perspective "दुहराओ" suits better.
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+function: "कार्य"
+  # ❓ @sshiv5768 "रचना" suits better programmatically
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+if: "अगर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+in: "में"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+select: "चयन"
+  # ✅ @sshiv5768 "चुनना" can also be used
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+then: "फिर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+time: "समय"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+until: "जब तक"
+  # ❓ @sshiv5768 "तब तक"
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+while: "जबकि"
+  # ❓ @sshiv5768 "जब तक"
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "स्वत:"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+double: "दोहरा"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+int: "पूर्णांक"
+  # ✅ @sshiv5768
+  # 🤔 @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+struct: "संरचना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+break: "विराम"
+  # ✅ @sshiv5768
+  # ❓ @bhaveshgoyal182 "तोड़ना"
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+else: "अन्य, और"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ❓ @179priyasoni "अन्यथा"
+  # ❓ @aadii0408 "अन्यथा"
+long: "लंबा"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+switch: "स्विच"
+  # ✅ @sshiv5768
+  # ❓ @bhaveshgoyal182 "बदलना"
+  # 👀 @179priyasoni
+  # ✅ @aadii0408
+case: "स्थिति"
+  # ✅ @sshiv5768
+  # ❓ @bhaveshgoyal182 "मामला"
+  # 👀 @179priyasoni
+  # ✅ @aadii0408
+enum: "गणना, परिगणना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+register: "सूची, दर्ज करना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+typedef: "परिभाषा का प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+char: "अक्षर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+extern: "extern"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+return: "वापस"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+union: "संयोजन"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+const: "अचल"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+float: "फ्लोट"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+short: "शोर्ट, छोटा"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+unsigned: "अहस्ताक्षरित"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+continue: "चालू रखना, जारी रखें"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+for: "के लिये"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+signed: "साइंड, पर हस्ताक्षर किए"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+void: "शून्य, रिक्त"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+default: "डिफ़ॉल्ट"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+goto: "इस पर चलें"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+sizeof: "का आकार"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+volatile: "परिवर्तनशील"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+do: "करना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+if: "अगर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+static: "स्थिर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+while: "जबकि"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+  # ✅ @179priyasoni
+  # ✅ @aadii0408
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: "परिभाषित"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#defined: "परिभाषित"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#else if: "और अगर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#else: "और, अन्य"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#endif: "अगर अंत"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#error: "त्रुटि"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#if: "अगर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#ifdef: "अगर परिभाषित किया गया है"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#ifndef: "यदि अपरिभाषित है"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#include: "शामिल, मिला हुआ"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#line: "लाइन"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#pragma: "pragma"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+#undef: "अपरिभाषित"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+alignas: "के रूप में संरेखित करें"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+alignof: "के संरेखित करें"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+and: "तथा"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+and_eq: "और बराबर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+asm: "asm"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+atomic_cancel: "atomic_cancel"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+atomic_commit: "atomic_commit"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+atomic_noexcept: "atomic_noexcept"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+auto: "स्वत"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+bitand: "बिटएंड"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+bitor: "बिटोर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+bool: "बूल"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+break: "विराम"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+case: "स्थित"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+catch: "पकड़ना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+char: "चार"
+  # ✅ @sshiv5768
+  # ❓ @bhaveshgoyal182 "शब्द"
+char16_t: "char16_t"
+  # 🤔 @sshiv5768
+  # 🤔 @bhaveshgoyal182
+char32_t: "char32_t"
+  # 🤔 @sshiv5768
+  # 🤔 @bhaveshgoyal182
+class: "वर्ग, कक्षा"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+compl: "compl"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+concept: "संकल्पना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+const: "अचल, स्थिर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+constexpr: "अचल अभिव्यक्ति"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+const_cast: "कंस्ट्कास्ट "
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+continue: "जारी रखें"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+decltype: "घोषणा प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+default: "डिफॉल्ट"
+  # ✅ @sshiv5768
+  # ❓ @bhaveshgoyal182 "अभाव" not of anytype
+delete: "मिटाना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+do: "करना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+double: "डबल"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+dynamic_cast: "डायनामिक कास्ट"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+else: "अन्य"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+enum: "परिगणना, गणना"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+explicit: "स्पष्ट, मुखर"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+export: "निर्यात"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+extern: "बाहरी"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+false: "असत्य"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+final: "अंतिम"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+float: "फ्लोट"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+for: "के लिये"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+friend: "मित्र"
+  # ✅ @sshiv5768
+  # ✅ @bhaveshgoyal182
+goto: "इस पर चलें"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+if: "अगर"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+inline: "इनलाइन"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+int: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+import: "आयात"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+long: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+module: "मापांक"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+mutable: "परिवर्तनशील"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+namespace: "नाम स्थान"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+new: "नया"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+noexcept: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+not: "नहीं"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+not_eq: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+nullptr: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+operator: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+or: "या"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+or_eq: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+override: "अवहेलना"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+private: "निजी"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+protected: "संरक्षित"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+public: "सार्वजनिक"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+register: "पंजी"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+reinterpret_cast: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+requires: "आवश्यक है"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+return: "वापसी"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+short: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+signed: "पर हस्ताक्षर किए"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+sizeof: "का आकार"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+static: "स्थिर"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+static_assert: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+static_cast: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+struct: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+switch: "बदलना"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+synchronized: "बदलना"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+template: "नमूना"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+this: "यह"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+thread_local: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+throw: "फेंकना"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+transaction_safe: "लेन-देन सुरक्षित"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+transaction_safe_dynamic: "लेनदेन सुरक्षित गतिशील"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+true: "सच"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+try: "प्रयत्न"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+typedef: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+typeid: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+typename: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+union: "संघ"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+unsigned: "अहस्ताक्षरित"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+using: "का उपयोग करते हुए"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+virtual: "आभासी"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+void: "शून्यता"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+volatile: "परिवर्तनशील"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+wchar_t: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+while: "जब तक"
+  # 👀 @sshiv5768
+  # ✅ @bhaveshgoyal182
+xor: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+xor_eq: ""
+  # 👀 @sshiv5768
+  # 👀 @bhaveshgoyal182
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: "विराम"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+default: "चूक"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+func: "कार्य"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+interface: "अंतराफलक"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+select: "चयन"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+case: "स्थिति"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+defer: "आस्थगित करें"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+go: "चलना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+map: "मैप"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+struct: "संरचना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+chan: "चान"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+else: "और"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+goto: "के लिए जाओ"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+package: "पैकेज, संकुल"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408 (also it should be more effective) "सन्दूक"
+switch: "बदलना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+const: "अचल"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+fallthrough: "असफल"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+if: "अगर"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+range: "सीमा"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+type: "प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+continue: "जारी रखें"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+for: "के लिये"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+import: "आयात"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+return: "वापसी"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+var: "वर"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408 Original word suits way better than tranlation
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: "जैसा"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+case: "स्थिति, परिस्थिति"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+of: "का"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+class: "वर्ग, कक्षा"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+data: "डेटा"
+  # ✅ @sshiv5768
+  # ❓ @aadii0408 "सामग्री"
+data family: "डेटा परिवार"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+data instance: "डेटा उदाहरण"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+default: "डिफ़ॉल्ट"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+deriving: "प्राप्त करना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+deriving instance: "व्युत्पन्न उदाहरण, उदाहरण प्राप्त करना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+do: "करना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+forall: "सबके लिए"
+  # ✅ @aadii0408
+  # ✅ @sshiv5768
+foreign: "बाह्य"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+hiding: "छुपा रहे है"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+if: "अगर"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+then: "फिर"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+else: "अन्य"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+import: "आयात"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+infix: "इन्फ़िक्स"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+infixl: "इन्फिक्सल "
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+infixr: "इन्फिक्सर"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+instance: "उदाहरण"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+let: "चलो"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+in: "में"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+mdo: "mdo"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408- better than any translation
+module: "मॉडुल, मापांक"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+newtype: "नया प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+proc: "proc"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+qualified: "योग्य"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+rec: "rec"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+type: "प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+type family: "परिवार प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+type instance: "उदाहरण प्रकार"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+where: "जहां"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: "संक्षेप"
+continue: "जारी रखें"
+for: "के लिए"
+new: "नया"
+switch: "बदलो"
+assert: "दावा करना"
+default: "चूक जाना"
+goto: "इस पर चलें"
+package: "संकुल"
+synchronized: "संकालन करना"
+boolean: "बूलियन"
+do: "कार्य करना"
+if: "यदि"
+private: "निजी"
+this: "यह"
+break: "विराम"
+double: "दोहरा"
+implements: "उपकरण"
+protected: "संरक्षित"
+throw: "फेंकना"
+byte: "बाइट"
+else: "अन्यथा"
+import: "आयात"
+public: "सार्वजनिक"
+throws: "फेंकता"
+case: "स्थिति"
+enum: "एन्यूम"
+instanceof: "का उदाहरण"
+return: "वापसी"
+transient: "क्षणिक"
+catch: "पकड़"
+extends: "विस्तृत करना"
+int: "पूर्णांक"
+short: "कम"
+try: "प्रयत्न"
+char: "शब्"
+final: "अंतिम"
+interface: "अंतराफलक"
+static: "अचल"
+void: "शून्य"
+class: "वर्ग"
+finally: "अंतिम रूप में"
+long: "दीर्घ"
+strictfp: "सख्त एफपी"
+volatile: "परिवर्तनशील"
+const: "स्थिरांक"
+float: "चल"
+native: "देशी"
+super: "उत्तम"
+while: "जब तक"
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: "पैरामीटर"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1
+await: "इंतजार"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+break: "विराम"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+case: "स्थिति"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 "मामला"
+catch: "पकड़ना"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+class: "वर्ग"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+const: "अचल"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1
+continue: "जारी रखें"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+debugger: "डीबगर"
+  # ✅ @sshekhar1996
+  # 🤔 @Nidhir2k1
+default: "डिफ़ॉल्ट"
+  # ✅ @sshekhar1996
+  # 🤔 @Nidhir2k1
+delete: "मिटायें"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 You can also use हटाना
+do: "करो"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+else: "अन्यथा"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+enum: "गिना हुआ"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1
+eval: "मूल्यांकन"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+export: "निर्यात"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+extends: "विस्तृत"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1
+false: "ग़लत"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+finally: "अंत में"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 "अन्ततोगत्वा"
+for: "के लिए"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+from: "द्वारा"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1 "स"
+function: "कार्य"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1
+if: "अगर"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+implements: "लागू"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+import: "आयात"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+in: "में"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+instanceof: "उदाहरण"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 "का" उदाहरण because "of" is the end
+interface: "अंतराफलक"
+  # ✅ @sshekhar1996
+  # 🤔 @Nidhir2k1
+let: "होने देना"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+new: "नया"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+null: "अमान्य"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 "खाली"
+package: "पैकेज"
+  # ✅ @sshekhar1996
+  # 🤔 @Nidhir2k1
+private: "निजी"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+protected: "संरक्षित"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+public: "सार्वजनिक"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+return: "वापस"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+static: "स्थिर"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+super: "उत्तम"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 not sure
+switch: "बदलो"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+this: "यह"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+throw: "फेंकना"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+true: "सच"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+try: "प्रयत्न"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+typeof: "प्रकार का"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+var: "परिवर्तनीय"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+void: "व्यर्थ"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1 रिक्त
+while: "जब तक"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+with: "लेकर"
+  # ✅ @sshekhar1996
+  # ✅ @Nidhir2k1
+yield: "मान जाना"
+  # ✅ @sshekhar1996
+  # ❓ @Nidhir2k1
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: "योजना"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+$ref: "संदर्भ"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+$id: "आईडी"
+  # ✅ @sshiv5768
+$comment: "टिप्पणी"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: "निर्देशिका का नाम"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+__filename: "फ़ाइल का नाम"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+exports: "निर्यात"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408
+module: "मॉड्यूल"
+  # ✅ @sshiv5768
+  # ✅ @aadii0408 - "भाग" (It should be more effective)
+require: "आवश्यक"
+  # ✅ @sshiv5768 require()
+  # ✅ @aadii0408
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+False: "असत्य"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+None: "कोई नहीं"
+  # ✅ @parammittal16
+  # ❓ @iofall "कुछ नहीं" This seems better in the context of none as a datatype
+  # ❓ @sshiv5768 "कुछ नहीं"
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ❓ @sneha-thyagarajan "कुछ नहीं" will go well with the context
+True: "सच"
+  # ✅ @parammittal16
+  # ❓ @iofall "सत्य"
+  # ❓ @sshiv5768 "सत्य"
+  # ✅ @Ln11211
+  # ❓ @nik132-eng "सत्य" is better
+  # ❓ @aadii0408 "सत्य"
+  # ✅ @sneha-thyagarajan
+and: "और"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+as: "के रूप में"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+assert: "जोर"
+  # ✅ @parammittal16
+  # ❓ @iofall "दावा करना" This one aligns better with the meaning of assert used in Python which is to claim/ give a data type and not "जोर" which would mean force
+  # ❓ @sshiv5768 "दावा करना"
+  # ❓ @Ln11211 I agree with "दावा करना"
+  # ❓ @nik132-eng "दावा करना"
+  # ❓ @aadii008 "दावा करना" This one suits better with the meaning of assert which we used in Python
+  # ❓ @sneha-thyagarajan "दावा करना" is better
+async: "async"
+  # ✅ @parammittal16
+  # ❓ @iofall Translation for asynchronous is "अतुल्यकालिक"
+  # ❓ @sshiv5768 "अतुल्यकालिक"
+  # ❓ @Ln11211 Contextually "अतुल्यकालिक" is apt, and is the only translation.
+  # ❓ @nik132-eng "अतुल्यकालिक" is better
+  # ✅ @aadii0408
+  # ❓ @sneha-thyagarajan i agree with "अतुल्यकालिक"
+await: "प्रतीक्षा करें"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+break: "टूटना"
+  # ✅ @parammittal16
+  # ❓ @iofall "तोडना" or maybe "समाप्त करना" to better fit the context of ending a loop
+  # ❓ @sshiv5768 "तोड़ना"
+  # ❓ @Ln11211 "समाप्त" seems to be more accurate and apt to the context
+  # ❓ @nik132-eng "तोड़ना" is better
+  # ❓ @aadi0408 "तोड़ना"
+  # ❓ @sneha-thyagarajan "तोड़ना" will be a close translation to the keyword "break"
+class: "वर्ग"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+continue: "जारी रखें"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ❓ @Ln11211 "बने रहना", as it seems simple and to the point
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+def: "def"
+  # ✅ @parammittal16
+  # ❓ @iofall "परिभाषा करना" since def stands for define
+  # ❓ @sshiv5768 "परिभाषा करना"
+  # ❓ @Ln11211 "परिभाषा करना"
+  # ❓ @nik132-eng "परिभाषा करना" is good to define
+  # ✅ @aadii0408
+  # ❓ @sneha-thyagarajan "परिभाषा" seems apt
+del: "डेल"
+  # ✅ @parammittal16
+  # ❓ @iofall "हटाना" or "मिटाना". "डेल" is just the phonetic translation
+  # ❓ @sshiv5768 "हटाना"
+  # ❓ @Ln11211 I agree with "मिटाना"
+  # ❓ @nik132-eng "हटाना" or "मिटाना" with both
+  # ❓ @aadii0408 "हटाना"
+  # ❓ @sneha-thyagarajan "मिटाना" will fit prefectly
+elif: "एलिफ"
+  # ✅ @parammittal16
+  # ❓ @iofall "अथवा अगर"
+  # ❓ @sshiv5768 "और अगर"
+  # ❓ @Ln11211 "अथवा अगर" is better.
+  # ❓ @nik132-eng "अथवा अगर" is better.
+  # ❓ @aadii0408 "और अगर" -is more effective.
+  # ❓ @sneha-thyagarajan "और अगर" is simple and better to understand
+else: "अन्य"
+  # ✅ @parammittal16
+  # ❓ @iofall "अन्यथा"
+  # ❓ @sshiv5768 "अन्य, अन्यथा"
+  # ❓ @Ln11211 "अन्य, अन्यथा"
+  # ❓ @nik132-eng "अन्य, अन्यथा" both are good
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+except: "सिवाय"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+finally: "अंत में"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+for: "के लिए"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+from: "से"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+global: "वैश्विक"
+  # ✅ @parammittal16
+  # ❓ @iofall "विश्वीय"
+  # ❓ @sshiv5768 "विश्वीय"
+  # ❓ @Ln11211 "विश्वीय" makes sense.
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+if: "यदि"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+import: "आयात"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+in: "में"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+is: "है"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+lambda: "लैम्ब्डा"
+  # ✅ @parammittal16
+  # 🤔 @iofall "लैम्ब्डा" is just a phonetic translation
+  # 👀 @sshiv5768
+  # ✅ @Ln11211 As it is named after a Greek letter, It can only be transalted as it is
+  # ✅ @nik132-eng "लैम्ब्डा" is greek letter so it shuold be trasalate as it is
+  # ✅ @sneha-thyagarajan i agree with the phonetic translation 
+nonlocal: "नॉनलोकल"
+  # ✅ @parammittal16
+  # ❓ @iofall "गैर स्थानीय". "नॉनलोकल" is just a phonetic translation of "nonlocal"
+  # ❓ @sshiv5768 "गैर स्थानीय"
+  # ❓ @Ln11211 "गैर स्थानीय"
+  # ❓ @nik132-eng "गैर स्थानीय"
+  # ❓ @sneha-thyagarajan "गैर स्थानीय" delivers the meaning of "nonlocal" well
+not: "नहीं"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+or: "या"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+pass: "पास"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+raise: "उठाना"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+return: "वापसी"
+  # ✅ @parammittal16
+  # ❓ @iofall "प्रतिदान"
+  # ❓ @sshiv5768 प्रतिदान
+  # ❓ @Ln11211 "प्रतिफल" as "प्रतिदान" means to trade or exchange while "प्रतिफल" means a return or a result.
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+try: "प्रयास करें"
+  # ✅ @parammittal16
+  # ❓ @iofall "प्रयास करना"
+  # ❓ @sshiv5768 "प्रयास करना"
+  # ❓ @Ln11211 "प्रयास करना"
+  # ❓ @nik132-eng "प्रयास करना"
+  # ❓ @sneha-thyagarajan "प्रयास करना" will fit well grammatically
+while: "जबकि"
+  # ✅ @parammittal16
+  # ❓ @iofall Better Alternative: "जब तक" This fits better to the while loop definition, since while follows while(condition). "जब तक" literally translates to "till when"
+  # ❓ @sshiv5768 "जब तक"
+  # ❓ @Ln11211 "जब तक"
+  # ❓ @nik132-eng "जब तक"
+  # ✅ @aadii0408
+  # ❓ @sneha-thyagarajan i think "जबकि" is wrong and should be "जब तक"
+with: "साथ"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+yield: "उपज"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @aadii0408
+  # ✅ @sneha-thyagarajan
+
+# << Built-In Functions >>
+
+abs: "एब्स"
+  # ✅ @parammittal16
+  # ❓ @iofall "परम" I think "पूर्ण" fits better for abs, which returns absolute value.
+  # ❓ @sshiv5768 "पूर्ण"
+  # ❓ @Ln11211 In Hindi, the Aboslute value goes by the name "निरपेक्ष मूल्य", using it would be better
+  # ❓ @nik132-eng "पूर्ण" is better
+  # ❓ @sneha-thyagarajan "निरपेक्ष" or "निरपेक्ष मूल्य" both will go well as "abs" will return absolute value regardless of its sign.
+all: "सभी"
+  # ✅ @parammittal16
+  # ❓ @iofall "सब"
+  # ❓ @sshiv5768 I agree with "सब", because it sounds perfect hindi translation
+  # ❓ @Ln11211 "सब"
+  # ❓ @nik132-eng "सब"
+  # ❓ @sneha-thyagarajan agree with "सब"
+any: "कोई भी"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ❓ @Ln11211 "सभी" is simple and better
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+ascii: "ascii"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "एस्की" . As there is no direct translation for the word "ascii" we can use the phonetic translation instead 
+bin: "बॉक्स"
+  # ✅ @parammittal16
+  # ❓ @iofall "दोहरा" maybe because "bin" refers to binary or just use "bin".
+  # ✅ @sshiv5768 "दोहरा"
+  # ❓ @Ln11211 would recommend using "बिन" as the bin() returns the binary
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "बिन" or "बाइनरी" is the phonetic translation and i recommend using it as direct translations won't be so effictive for this
+bool: "बुल"
+  # ✅ @parammittal16
+  # ✅ @iofall Correct Spelling "बूल"
+  # ✅ @sshiv5768 "बूल"
+  # ✅ @Ln11211 "बूल"
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+breakpoint: "ब्रेकपॉइंट"
+  # ✅ @parammittal16
+  # ❓ @iofall "विराम बिंदु"
+  # ❓ @sshiv5768 "विराम बिंदु"
+  # ❓ @Ln11211 "विराम बिंदु"
+  # ❓ @nik132-eng "विराम बिंदु"
+  # ❓ @sneha-thyagarajan i recommend "विराम स्थान", as in "विराम बिंदु" 'बिंदु' directly translating to 'point.' However, when explaining the term 'break-point,' the literal translation of 'बिंदु' may not fully convey the intended meaning.
+bytearray: "बाइट"
+  # ✅ @parammittal16
+  # ❓ @iofall "बाइट अरे" or maybe "बाइट सरणी"
+  # ❓ @sshiv5768 "बाइट अरे"
+  # ❓ @Ln11211 "बाइट अरे"
+  # ❓ @nik132-eng "बाइट अरे" is better
+  # ❓ @sneha-thyagarajan "बाइट अरे"
+bytes: "बाइट्स"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+callable: "कॉल करने योग्य"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+chr: "chr"
+  # ✅ @parammittal16
+  # ❓ @iofall "अक्षर" I believe data types should be kept as it is just change them phonetically if needed
+  # ❓ @sshiv5768 "चर"
+  # ❓ @Ln11211 "चर"
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "चर"
+classmethod: "वर्गमूल"
+  # ✅ @parammittal16
+  # ❓ @iofall "वर्ग विधि"
+  # ❓ @sshiv5768 "वर्ग विधि"
+  # ❓ @Ln11211 "वर्ग विधि"
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "वर्ग विधि"
+compile: "संकलन"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+complex: "जटिल"
+  # ✅ @parammittal16
+  # ❓ @iofall "पेचीदा"
+  # ❓ @sshiv5768 "पेचीदा"
+  # ❓ @Ln11211 Here "complex" refers to the function that returns a complex number,thus using "समिश्र" from "समिश्र संख्या"(menaing complex number)would be close and appropriate
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan  agree with "समिश्र संख्या"
+delattr: "delattr"
+  # ✅ @parammittal16
+  # ❓ @iofall "गुण हटाना" or "विशेषता हटाना"
+  # ❓ @sshiv5768 "विशेषता हटाना"
+  # ❓ @Ln11211 I think "गुण हटाना" is apt as in L1314 गुण is used too
+  # ❓ @nik132-eng "विशेषता हटाना"
+  # ❓ @sneha-thyagarajan  "गुण हटाना"
+dict: "परिभाषा"
+  # ✅ @parammittal16
+  # 🤔 @iofall maybe "कोश" I think "कोश" suits better for dict
+  # 👀 @sshiv5768 "कोश"
+  # ✅ @Ln11211 "कोश"
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan  "कोश"
+dir: "dir"
+  # ✅ @parammittal16
+  # 🤔 @iofall maybe "निर्देशिका"
+  # ❓ @sshiv5768 "निर्देशिका"
+  # ❓ @Ln11211 "निर्देशिका"
+  # ❓ @nik132-eng "निर्देशिका"
+  # ❓ @sneha-thyagarajan  "निर्देशिका" is correct
+divmod: "विभाजन शेष"
+  # ✅ @parammittal16
+  # 🤔 @iofall maybe "विभाजन शेष"
+  # ❓ @sshiv5768 "विभाजन शेष"
+  # ❓ @Ln11211 "विभाजन शेष"
+  # ❓ @nik132-eng "निर्देशिका"
+  # ❓ @sneha-thyagarajan  "विभाजन शेष"
+enumerate: "गणना करें"
+  # ✅ @parammittal16
+  # ❓ @iofall "गणना करना"
+  # ❓ @sshiv5768 "गणना करना"
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "गणना करना" will be better grammatically
+eval: "eval"
+  # ✅ @parammittal16
+  # ❓ @iofall "मूल्यांकन करना"
+  # ❓ @sshiv5768 "मूल्यांकन करना"
+  # ❓ @Ln11211 "मूल्यांकन करना"
+  # ❓ @nik132-eng "मूल्यांकन करना"
+  # ❓ @sneha-thyagarajan "मूल्यांकन करना"
+exec: "निष्पादित करें"
+  # ✅ @parammittal16
+  # ❓ @iofall "निष्पादित करना"
+  # ❓ @sshiv5768 "निष्पादित करना"
+  # ❓ @Ln11211 "निष्पादित करना"
+  # ❓ @nik132-eng "मूल्यांकन करना"
+  # ❓ @sneha-thyagarajan "निष्पादित करना"
+filter: "फ़िल्टर"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan agree with this as there is no other apt translation
+float: "फ्लोट"
+  # ✅ @parammittal16
+  # ✅ @iofall I believe data types should be kept as it is just change them phonetically if needed
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+format: "प्रारूप"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+frozenset: "फ्रोजन"
+  # ✅ @parammittal16
+  # ❓ @iofall "जमा हुआ समूह" or "स्तम्भित समूह" frozenset is an abstract data-type so that I think it should be remail original or phoneticly translated
+  # ❓ @sshiv5768 "फ्रोज़ेनसेट"
+  # ❓ @Ln11211 "फ्रोज़ेनसेट"
+  # ❓ @nik132-eng "फ्रोज़ेनसेट"
+  # ❓ @sneha-thyagarajan "फ्रोज़ेनसेट"
+getattr: "getattr"
+  # ✅ @parammittal16
+  # ❓ @iofall "गुण लेना" or "गुण प्राप्त करना" or "विशेषता प्राप्त करना"
+  # ❓ @sshiv5768 "गुण प्राप्त करना"
+  # ❓ @Ln11211 "गुण प्राप्त करना"
+  # ❓ @nik132-eng "गुण प्राप्त करना"
+  # ❓ @sneha-thyagarajan "गुण प्राप्त करना"
+globals: "ग्लोबल्स"
+  # ✅ @parammittal16
+  # ❓ @iofall "वैश्विक" or "विश्वीय"
+  # ❓ @sshiv5768 "वैश्विक"
+  # ❓ @Ln11211 "वैश्विक"
+  # ❓ @nik132-eng "वैश्विक"
+  # ❓ @sneha-thyagarajan "वैश्विक"
+hasattr: "hasattr"
+  # ✅ @parammittal16
+  # ❓ @iofall "गुण होना" or "विशेषता होना"
+  # ❓ @sshiv5768 "विशेषता होना"
+  # ❓ @Ln11211 "गुण होना" seems better
+  # ❓ @nik132-eng "विशेषता होना"
+  # ❓ @sneha-thyagarajan "विशेषता होना"
+hash: "हैश"
+  # ✅ @parammittal16
+  # ✅ @iofall or just use English versions
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+help: "मदद"
+  # ✅ @parammittal16
+  # ✅ @iofall or just use English versions
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+hx: "हेक्स"
+  # ✅ @parammittal16
+  # ✅ @iofall or just use English versions
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+id: "आईडी"
+  # ✅ @parammittal16
+  # ✅ @iofall or just use English versions
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "पहचान". As "आईडी" is a phonetic translation and "पहचान" can be used as it means identity which can be unique
+input: "इनपुट"
+  # ✅ @parammittal16
+  # 🤔 @iofall maybe "आगत"
+  #  @sshiv5768 आगत
+  # ❓ @Ln11211 "आगत" is correct
+  # ❓ @nik132-eng "आगत"
+  # ❓ @sneha-thyagarajan "आगत"
+int: "पूर्णांक"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+isinstance: "isinstance"
+  # ✅ @parammittal16
+  # ❓ @iofall "उदाहरण है"
+  # ❓ @sshiv5768 "उदाहरण है"
+  # ❓ @Ln11211 I think "अवस्था है" is better
+  # ❓ @nik132-eng "उदाहरण है"
+  # ❓ @sneha-thyagarajan "वर्ग का सदस्य है" is better , it translates to "is a member of a class"
+issubclass: "इसस्क्क्लास"
+  # ✅ @parammittal16
+  # ❓ @iofall "उपवर्ग है"
+  # ❓ @sshiv5768 "उपवर्ग है"
+  # ❓ @Ln11211 "उपवर्ग है"
+  # ❓ @nik132-eng "उपवर्ग है"
+  # ❓ @sneha-thyagarajan "उपवर्ग है"
+iter: "पुनरावृति करना"
+  # ✅ @parammittal16
+  # 🤔 @iofall "पुनरावृति करना" or "दुहराना" or "बार-बार करना"
+  # ❓ @sshiv5768 "पुनरावृति करना"
+  # ❓ @Ln11211 "बार-बार करने वाला" if referring to the iter()
+  # ❓ @nik132-eng "पुनरावृति करना"
+  # ✅ @sneha-thyagarajan 
+len: "लंबाई"
+  # ✅ @parammittal16
+  # ❓ @iofall "लंबाई" or "विस्तार" is more appropriate in the context of "len" as used in Python
+  # ❓ @sshiv5768 "लंबाई"
+  # ❓ @Ln11211 "लंबाई" means length and len() is usually used to get length, so seems apt
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+list: "सूची"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+locals: "स्थानीय"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+map: "नक्शा"
+  # ✅ @parammittal16
+  # ❓ @iofall "तलरूप-मिति करना" if you consider "map" in the verb form otherwise "नक्शा" seems correct
+  # ❓ @sshiv5768 "तलरूप-मिति करना"
+  # ❓ @Ln11211 "नक्शा" is better
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+max: "अधिकतम"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+memoryview: "मेमोरीव्यू"
+  # ✅ @parammittal16
+  # ❓ @iofall "स्मृति दर्शन"
+  # ❓ @sshiv5768 "स्मृति दर्शन"
+  # 🤔 @Ln11211 memoryview is used to expose Python buffer protocol, thus it should remain as it in english, and the literal(machine) translation "स्मृति दर्शन" seems inappropriate
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+min: "न्यूनतम"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+next: "अगला"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+object: "ऑब्जेक्ट"
+  # ✅ @parammittal16
+  # ❓ @iofall "वस्तु"
+  # ❓ @sshiv5768 "वस्तु"
+  # ❓ @Ln11211 object is a fundamental concept in programming(specifically in OOP) and it in best left as it is or at the most translated as "ऑब्जेक्ट".
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+oct: "अष्ट"
+  # ✅ @parammittal16
+  # ✅ @iofall or just use English versions
+  # 👀 @sshiv5768
+  # ✅ @Ln11211 similar to bin() method, the oct() returns octal form, thus the translation seems apt.
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+open: "खुला"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+ord: "ऑर्डर"
+  # ✅ @parammittal16
+  # ❓ @iofall "ऑर्ड"
+  # ❓ @sshiv5768 "ऑर्ड"
+  # ❓ @Ln11211 ord() function returns unicode, thus leaving it as it is in english or using "ऑर्ड" is apt.
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+pow: "पाउ"
+  # ✅ @parammittal16
+  # ❓ @iofall "घातांक"
+  # ❓ @sshiv5768 "घातांक"
+  # ❓ @Ln11211 "घातांक" is an awesome translation
+  # ❓ @nik132-eng "घातांक"
+  # ❓ @sneha-thyagarajan "घातांक
+
+print: "प्रिंट"
+  # ✅ @parammittal16
+  # ❓ @iofall "छापना" but "print" is used in everyday speak as well, not sure whether translation is required here
+  # ❓ @sshiv5768 "प्रिंट,छापन"
+  # ✅ @Ln11211 "प्रिंट" is enough
+  # ❓ @nik132-eng "छापना"
+  # ✅ @sneha-thyagarajan
+property: "संपत्ति"
+  # ✅ @parammittal16
+  # ❓ @iofall "स्वभाव" or maybe "लक्षण" or "विशेषता"
+  # ❓ @sshiv5768 "लक्षण, विशेषता"
+  # ❓ @Ln11211 "विशेषता" seems to suit well
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "लक्षण" as it translates as characteristics/ properties
+range: "रेंज"
+  # ✅ @parammittal16
+  # ❓ @iofall "सीमा"
+  # ❓ @sshiv5768 "सीमा"
+  # ❓ @Ln11211 using "रेंज" would make better sense as it is often used as a looping structuer or to iterate
+  # ❓ @nik132-eng "सीमा"
+  # ❓ @sneha-thyagarajan "सीमा"
+repr: "repr"
+  # ✅ @parammittal16
+  # 🤔 @iofall
+  # 👀 @sshiv5768
+  # 🤔 @Ln11211 repr() returns the string representation of passes values, so its recommended to use it as it is or to translate it phonetically
+  # 🤔 @nik132-eng
+  # 🤔 @sneha-thyagarajan hard to translate , can use "रिपर" (phonetic translation)
+reversed: "औंधा"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+round: "गोल"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ❓ @Ln11211 using "पूर्णांकित" is better as round() is used to round off to nearest decimal,thus "पूर्णांकित" is derived from "पूर्णांकित करना"(round off)
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan  agree with "पूर्णांकित" as "गोल" cannot deliver the meaning correctly
+set: "समूह"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ❓ @Ln11211 Just not sure about "समूह"
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+setattr: "setattr"
+  # ✅ @parammittal16
+  # ❓ @iofall "गुण लगाना" or "गुण स्थापित करना" or "विशेषता लगाना" or "विशेषता स्थापित करना"
+  # ❓ @sshiv5768 "विशेषता लगाना"
+  # ❓ @Ln11211 I think "गुण स्थापित करन" is apt
+  # ❓ @nik132-eng "विशेषता लगाना"
+  # ❓ @sneha-thyagarajan "गुण लगाना"
+slice: "टुकड़ा"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+sorted: "छाँटे गए"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+staticmethod: "स्थिर"
+  # ✅ @parammittal16
+  # ❓ @iofall "स्थिर विधि"
+  # ❓ @sshiv5768 "स्थिर विधि"
+  # 🤔 @Ln11211 I recommend translating it phonetically or letting it remain as it is in english
+  # ❓ @nik132-eng "स्थिर विधि"
+  # ❓ @sneha-thyagarajan "स्थिर विधि"
+str: "str"
+  # ✅ @parammittal16
+  # ✅ @iofall I believe data types should be kept as it is just change them phonetically if needed
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+sum: "योग"
+  # ✅ @parammittal16
+  # ❓ @iofall "जोड" or "योगफल"
+  # ❓ @sshiv5768 "जोड़"
+  # ❓ @Ln11211 as suggested in earlier comment "योगफल" seems better
+  # ❓ @nik132-eng "जोड़"
+  # ❓ @sneha-thyagarajan "जोड़"
+super: "उत्तम"
+  # ✅ @parammittal16
+  # 🤔 @iofall "बढ़िया" or "उत्तम" is the correct translation but not sure if it should be used since the use of "super" keyword does not relate to its literal meaning. So keep it as "super" only
+  # 👀 @sshiv5768
+  # ❓ @Ln11211 would recommend using "super" only
+  # ✅ @nik132-eng
+  # ❓ @sneha-thyagarajan "सूपर" is the phonetic translation and i recommend it , "उत्तम" seems wrong according perspective of programming
+tuple: "tuple"
+  # ✅ @parammittal16
+  # ❓ @iofall Phonetic - "टपल"
+  # ❓ @sshiv5768 "टपल"
+  # ❓ @Ln11211 "टपल"
+  # ❓ @nik132-eng "टपल"
+  # ❓ @sneha-thyagarajan  "टपल"
+type: "प्रकार"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+vars: "जिसका"
+  # ✅ @parammittal16
+  # ❓ @iofall "जिसका" is wrong. Variables are called as "चर" in Hindi Mathematics. This fits the usage of "vars" since it returns a dictionary of variables in a class instance. So "चर" should be used.
+  # ❓ @sshiv5768 "चर"
+  # ❓ @Ln11211 "चर"
+  # ❓ @nik132-eng "चर"
+  # ❓ @sneha-thyagarajan "चर"
+zip: "ज़िप"
+  # ✅ @parammittal16
+  # 🤔 @iofall
+  # 👀 @sshiv5768
+  # 🤔 @Ln11211 Would recommend using zip as it is a well known word and mostly in use.
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+__import__: "__आयात__"
+  # ✅ @parammittal16
+  # ✅ @iofall
+  # 👀 @sshiv5768
+  # ✅ @Ln11211
+  # ✅ @nik132-eng
+  # ✅ @sneha-thyagarajan
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/id.yml
+++ b/locale/id.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "id"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Salah" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  None: "Kosong" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  True: "Benar" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  and: "dan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  as: "sebagai" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  assert: "menyatakan" # ❓ @Wrth1 "pastikan", ✅@Takane42, ✅ @mhmdbhsk
+  async: "asinkron" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  await: "menunggu" # ❓ @Wrth1 "tunggu", ✅ @Takane42, ✅ @mhmdbhsk
+  break: "hentikan" # ❓ @Wrth1 "berhenti" atau "henti" karena terjemahan continue juga tidak memiliki 'kan', ❓@Takane42 Berhenti, ❓@mhmdbhsk "Berhenti"
+  class: "kelas" # ✅ @Wrth1, 🤔 @Takane42,🤔 @mhmdbhsk
+  continue: "lanjut" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  def: "menetapkan" # ❓ @Wrth1 "tetapkan", ❓ @Takane42 "tetapkan",❓ @mhmdbhsk "tetapkan"
+  del: "hapus" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  elif: "lainnya jika" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  else: "lainnya" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  except: "kecuali" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  finally: "akhir" # ❓ @Wrth1 "akhirnya" ada ly nya, ❓ @Takane42 "Akhirnya" bener kata @Wrth1, ❓ @mhmdbhsk "Akhirnya"
+  for: "untuk" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  from: "dari" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  global:  "global" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  if: "jika" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  import: "impor" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  in: "dalam" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  is: "adalah" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  lambda: "lambda" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  nonlocal: "non lokal" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  not: "tidak" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  or: "atau" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  pass: "lewati" # ✅ @Wrth1, ❓ @Takane42 ini bisa "Lewati" atau "oke",❓ @mhmdbhsk "lewati" / "oke" / "sukses"
+  raise: "angkat" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  return: "kembali" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  try: "coba" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  while: "selama" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  with: "dengan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  yield: "hasil" # ❓ @Wrth1 "hasilkan", ❓ @Takane42 "Menghasilkan",🤔 @mhmdbhsk
+
+# << Built-In Functions >>
+
+  abs: "mutlak" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  all: "semua" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  any: "apapun" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  ascii: "ascii" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  bin: "biner" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  bool: "bool" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  breakpoint: "titik henti" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  bytearray: "himpunan byte" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  bytes: "bytes" # ✅ @Wrth1, 🤔 @Takane42, ❓ @mhmdbhsk "byte" indonesia tidak ada jamak
+  callable: "dapat dipanggil" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  chr: "karakter" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  classmethod: "metode kelas" # ✅ @Wrth1, ❓ @Takane42 "Metode Class", ❓ @mhmdbhsk "Metode Class"
+  compile: "menyusun" # ❓ @Wrth1 "susun", ✅ @Takane42, ✅ @mhmdbhsk
+  complex: "kompleks" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  delattr: "hapus atribut" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  dict: "kamus" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  dir: "direktori" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  divmod: "pembagian dan modulus" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  enumerate: "menghitung" # ❓ @Wrth1 "enumerasi", 🤔 @mhmdbhsk
+  eval: "evaluasi" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  exec: "eksekusi" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  filter: "filter" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  float: "pecahan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  format: "format" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  frozenset: "objek beku" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  getattr: "dapatkan atribut" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  globals: "global" # ✅ @Wrth1 tetapi terjemahannya jadi sama dengan keyword global, ✅ @Takane42, ✅ @mhmdbhsk
+  hasattr: "punya atribut" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  hash: "campuran" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  help: "bantuan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  hex: "heksa" # ❓ @Wrth1 "heksadesimal", ❓ @Takane42 "heksadesimal" iya harusnya heksadesimal, ❓ @mhmdbhsk "heksadesimal"
+  id: "identitas" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  input: "masukan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  int: "bilangan bulat" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  isinstance: "adalah contoh" # ❓ @Wrth1 "adalah hal", 🤔 @mhmdbhsk
+  issubclass: "adalah subkelas" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  iter: "iterasi" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  len: "panjang" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  list: "daftar" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  locals: "lokal" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  map: "petakan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  max: "maksimal" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  memoryview: "tampilan memori" # ✅ @Takane42, ✅ @mhmdbhsk
+  min: "minimal" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  next: "berikutnya" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  object: "obyek" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  oct: "oktal" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  open: "buka" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  ord: "ord" # ✅ @Wrth1, 🤔 @Takane42, 🤔 @mhmdbhsk
+  pow: "pangkat" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  print: "cetak" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  property: "properti" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  range: "jarak" # ❓ @Wrth1 "area" "wilayah" "radius", ❓ @Takane42 "Area",❓ @mhmdbhsk "area" "radius"
+  repr: "representasi" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  reversed: "terbalik" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  round: "bulat" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  set: "set" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  setattr: "set atribut" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  slice: "irisan" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  sorted: "urutkan" # ❓ @Wrth1 "terurut",❓ @Takanae42 "Telah diurutkan", ❓ @mhmdbhsk "Telah diurutkan"
+  staticmethod: "metode statis" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  str: "rangkaian" # ❓ @Wrth1 "teks" atau sesuatu yang lebih berkaitan ke rangkaian karakter, 🤔 @mhmdbhsk
+  sum: "jumlah" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  super: "super" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  tuple: "tupel" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  type: "tipe" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  vars: "variabel" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  zip: "zip" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+  __import__: "__impor__" # ✅ @Wrth1, ✅ @Takane42, ✅ @mhmdbhsk
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/it.yml
+++ b/locale/it.yml
@@ -1,0 +1,2688 @@
+# I file nella cartella locale sono utilizzati per la localizzazione.
+# Se vuoi usare un locale che non sia l'inglese, segui le istruzioni nella guida di legesher-translation:
+# https://legesher.readme.io/docs/translation-guide
+#
+# GRAZIE PER RENDERE LEGESHER PIÙ GRANDE DI NOI.
+
+# NOTA: "Abbrerviazione-lingua"
+language-abbreviation: "it"
+
+# ----------------------
+# |    SISTEMA: ATOM    |
+# ----------------------
+# << PAROLE CHIAVE  >>
+# NOTA: Tutte le parole chiave sono scritte in maiuscolo per Atom perché è utilizzato per
+# le informazioni chiave locate nei commenti all'interno dell'editor.
+  NOTE: "NOTA"
+    # ✅ @ninoCan
+  INFO: "INFORMAZIONE"
+    # ✅ @ninoCan
+  IDEA: "IDEA"
+    # ✅ @ninoCan
+  DEBUG: "CORREZIONE"
+    # ✅ @ninoCan
+  REMOVE: "RIMUOVI"
+    # ✅ @ninoCan
+  OPTIMIZE: "OTTIMIZZA"
+    # ✅ @ninoCan
+  REVIEW: "REVISIONA"
+    # ✅ @ninoCan
+  HACK: "TRUCCO"
+    # ✅ @ninoCan
+  UNDONE: "INCOMPLETO"
+    # ✅ @ninoCan
+  TODO: "DAFARE"
+    # ✅ @ninoCan
+  REFACTOR: "RIFATTORIZZA"
+    # ✅ @ninoCan
+  DEPRECATED: "DEPRECATO"
+    # ✅ @ninoCan
+  TASK: "COMPITO"
+    # ✅ @ninoCan
+  CHGME: "CAMBIAMI"
+    # ✅ @ninoCan
+  NOTREACHED: "IRRAGIUNTO"
+    # ✅ @ninoCan
+  WTF: "CHECAZ20"
+    # ✅ @ninoCan
+  BUG: "BACO"
+    # ✅ @ninoCan
+  ERROR: "ERROR"
+    # ✅ @ninoCan
+  OMG: "OHMIODIO"
+    # ✅ @ninoCan
+  ERR: "EHM"
+    # ✅ @ninoCan
+  OMFGRLY: "OMMIODDIOVERAMENTE"
+    # ✅ @ninoCan
+  WARNING: "CAUZIONE"
+    # ✅ @ninoCan
+  WARN: "ATTENZIONE"
+    # ✅ @ninoCan
+  BROKEN: "ROTTO"
+    # ✅ @ninoCan
+
+# ----------------------
+# |   LINGUAGGIO: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: "riassunto"
+    # ✅ @ninoCan
+  codata: "codato"
+    # ✅ @ninoCan
+  coinductive: "coinduttivo"
+    # ✅ @ninoCan
+  constructor: "construtto"
+    # ✅ @ninoCan
+  data: "dato"
+    # ✅ @ninoCan
+  do: "fai"
+    # ✅ @ninoCan
+  eta-equality: "eta-uguaglianza"
+    # ✅ @ninoCan
+  field: "campo"
+    # ✅ @ninoCan
+  forall: "pertutti"
+    # ✅ @ninoCan
+  hiding: "nascosto"
+    # ✅ @ninoCan
+  import: "importa"
+    # ✅ @ninoCan
+  in: "in"
+    # ✅ @ninoCan
+  inductive: "induttivo"
+    # ✅ @ninoCan
+  infix: "infisso"
+    # ✅ @ninoCan
+  infixl: "infissol"
+    # ✅ @ninoCan
+  infixr: "infissor"
+    # ✅ @ninoCan
+  instance: "istanza"
+    # ✅ @ninoCan
+  let: "sia"
+    # ✅ @ninoCan
+  macro: "macro"
+    # ✅ @ninoCan
+  module: "modulo"
+    # ✅ @ninoCan
+  mutual: "mutuo"
+    # ✅ @ninoCan
+  no-eta-equality: "non-eta-uguaglianza"
+    # ✅ @ninoCan
+  open: "apri"
+    # ✅ @ninoCan
+  overlap: "sovrapponi"
+    # ✅ @ninoCan
+  pattern: "motivo"
+    # ✅ @ninoCan
+  postulate: "postula"
+    # ✅ @ninoCan
+  primitive: "primitiva"
+    # ✅ @ninoCan
+  private: "privato"
+    # ✅ @ninoCan
+  public: "pubblico"
+    # ✅ @ninoCan
+  quote: "virgoletta"
+    # ✅ @ninoCan
+  quoteContext: "citaContesto"
+    # ✅ @ninoCan
+  quoteGoal: "citaObbiettivo"
+    # ✅ @ninoCan
+  quoteTerm: "citaTermine"
+    # ✅ @ninoCan
+  record: "registro"
+    # ✅ @ninoCan
+  renaming: "rinomina"
+    # ✅ @ninoCan
+  rewrite: "riscrivi"
+    # ✅ @ninoCan
+  Set: "Instituisci"
+    # ✅ @ninoCan can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "sintassi"
+    # ✅ @ninoCan
+  tactic: "tattica"
+    # ✅ @ninoCan
+  unquote: "chiudiVirgoletta"
+    # ✅ @ninoCan
+  unquoteDecl: "chiudiDich"
+    # ✅ @ninoCan
+  unquoteDef: "chiudiDef"
+    # ✅ @ninoCan
+  using: "usando"
+    # ✅ @ninoCan
+  where: "dove"
+    # ✅ @ninoCan
+  with: "con"
+    # ✅ @ninoCan
+
+# << Messaggi d'errore >>
+
+# ----------------------
+# |   LINGUAGGIO: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTA: https://www.amibroker.com/guide/a_language.html
+
+# << parole chiave >>
+do: "fai" # (part of do-while statement)
+  # ✅ @ninoCan
+while: "mentre"
+  # ✅ @ninoCan
+for: "per"
+  # ✅ @ninoCan
+if: "se" # (part of if-else statement)
+  # ✅ @ninoCan
+else: "altrimenti" # (part of if-else statement)
+  # ✅ @ninoCan
+switch: "cambia"
+  # ✅ @ninoCan
+break: "interrompi" # (part of the switch statement or for/while statements)
+  # ✅ @ninoCan
+case: "caso" # (part of the switch statement)
+  # ✅ @ninoCan
+continue: "continua" # (part of for/while statements)
+  # ✅ @ninoCan
+default: "default" # (part of switch statement)
+  # ✅ @ninoCan
+function: "funzione"
+  # ✅ @ninoCan
+procedure: "procedura"
+  # ✅ @ninoCan
+return: "restituiscia"
+  # ✅ @ninoCan
+local: "locale"
+  # ✅ @ninoCan
+global: "globale"
+  # ✅ @ninoCan
+static: "statico"
+  # ✅ @ninoCan
+typeof: "tipodi"
+  # ✅ @ninoCan
+NOT: "NON"
+  # ✅ @ninoCan
+AND: "ED"
+  # ✅ @ninoCan
+OR: "OD"
+  # ✅ @ninoCan
+Null: "Zero"
+  # ✅ @ninoCan
+# << Messaggi d'errore>>
+
+# ----------------------
+# |   LINGUAGGIO: BASH   |
+# ----------------------
+# << Parole chiave >>
+case: "caso"
+  # ✅ @ninoCan
+do: "fai"
+  # ✅ @ninoCan
+done: "fatto"
+  # ✅ @ninoCan
+elif: "altrose"
+  # ✅ @ninoCan
+else: "altrimenti"
+  # ✅ @ninoCan
+esac: "osac"
+  # ✅ @ninoCan
+fi: "es"
+  # ✅ @ninoCan
+for: "per"
+  # ✅ @ninoCan
+function: "funzione"
+  # ✅ @ninoCan
+if: "se"
+  # ✅ @ninoCan
+in: "in"
+  # ✅ @ninoCan
+select: "seleziona"
+  # ✅ @ninoCan
+then: "allora"
+  # ✅ @ninoCan
+time: "tempo"
+  # ✅ @ninoCan
+until: "finanche"
+  # ✅ @ninoCan
+while: "mentre"
+  # ✅ @ninoCan
+
+# << Messaggi d'errore >>
+
+# ----------------------
+# |   LINGUAGGIO : C      |
+# ----------------------
+# << Parole chiave >>
+auto: "auto"
+  # ✅ @ninoCan
+double: "doppio"
+  # ✅ @ninoCan
+int: "intero"
+  # ✅ @ninoCan
+struct: "struttura"
+  # ✅ @ninoCan
+break: "interrompi"
+  # ✅ @ninoCan
+else: "altrimenti"
+  # ✅ @ninoCan
+long: "lungo"
+  # ✅ @ninoCan
+switch: "cambia"
+  # ✅ @ninoCan
+case: "caso"
+  # ✅ @ninoCan
+enum: "enumera"
+  # ✅ @ninoCan
+register: "registro"
+  # ✅ @ninoCan
+typedef: "definiscitipo"
+  # ✅ @ninoCan
+char: "carattere"
+  # ✅ @ninoCan
+extern: "esterno"
+  # ✅ @ninoCan
+return: "restituisci"
+  # ✅ @ninoCan
+union: "unione"
+  # ✅ @ninoCan
+const: "costante"
+  # ✅ @ninoCan
+float: "mobile"
+  # ✅ @ninoCan
+short: "corto"
+  # ✅ @ninoCan
+unsigned: "anonimo"
+  # ✅ @ninoCan
+continue: "continua"
+  # ✅ @ninoCan
+for: "per"
+  # ✅ @ninoCan
+signed: "firmato"
+  # ✅ @ninoCan
+void: "vuoto"
+  # ✅ @ninoCan
+default: "default"
+  # ✅ @ninoCan
+goto: "vaiad"
+  # ✅ @ninoCan
+sizeof: "dimensionedi"
+  # ✅ @ninoCan
+volatile: "volatile"
+  # ✅ @ninoCan
+do: "fai"
+  # ✅ @ninoCan
+if: "se"
+  # ✅ @ninoCan
+static: "statico"
+  # ✅ @ninoCan
+while: "mentre"
+  # ✅ @ninoCan
+
+# << Messaggi d'errore >>
+
+# ----------------------
+# |   LINGUAGGIO:  C++   |
+# ----------------------
+# << Parole chiave >>
+
+#define: "definisci"
+  # ✅ @ninoCan
+#defined: "definito"
+  # ✅ @ninoCan
+#elif: "altrose"
+  # ✅ @ninoCan
+#else: "altrimenti"
+  # ✅ @ninoCan
+#endif: "finese"
+  # ✅ @ninoCan
+#error: "errore"
+  # ✅ @ninoCan
+#if: "se"
+  # ✅ @ninoCan
+#ifdef: "sedefinisci"
+  # ✅ @ninoCan
+#ifndef: "senondefinisci"
+  # ✅ @ninoCan
+#include: "includi"
+  # ✅ @ninoCan
+#line: "linea"
+  # ✅ @ninoCan
+#pragma: "pragma"
+  # ✅ @ninoCan
+#undef: "libera"
+  # ✅ @ninoCan
+alignas: ""
+  # 👀 @ninoCan
+alignof: ""
+  # 👀 @ninoCan
+and: ""
+  # 👀 @ninoCan
+and_eq: ""
+  # 👀 @ninoCan
+asm: ""
+  # 👀 @ninoCan
+atomic_cancel: ""
+  # 👀 @ninoCan
+atomic_commit: ""
+  # 👀 @ninoCan
+atomic_noexcept: ""
+  # 👀 @ninoCan
+auto: "auto"
+  # ✅ @ninoCan
+bitand: "ebinario"
+  # ✅ @ninoCan
+bitor: "obinario"
+  # ✅ @ninoCan
+bool: "boleano"
+  # ✅ @ninoCan
+break: "interrompi"
+  # ✅ @ninoCan
+case: "caso"
+  # ✅ @ninoCan
+catch: "prendi"
+  # ✅ @ninoCan
+char: "carattere"
+  # ✅ @ninoCan
+char16_t: "carattere_16_t"
+  # ✅ @ninoCan
+char32_t: "carattere32_t"
+  # ✅ @ninoCan
+class: "classe"
+  # ✅ @ninoCan
+compl: "complemento"
+  # ✅ @ninoCan
+concept: "concetto"
+  # ✅ @ninoCan
+const: "costante"
+  # ✅ @ninoCan
+constexpr: "espressionecostante"
+  # ✅ @ninoCan
+const_cast: "chiamata_costante"
+  # ✅ @ninoCan
+continue: "continua"
+  # ✅ @ninoCan
+decltype: "dichiaratipo"
+  # ✅ @ninoCan
+default: "default"
+  # ✅ @ninoCan
+delete: "cancella"
+  # ✅ @ninoCan
+do: "fai"
+  # ✅ @ninoCan
+double: "doppio"
+  # ✅ @ninoCan
+dynamic_cast: "chiamata_dinamica"
+  # ✅ @ninoCan
+else: "altrimenti"
+  # ✅ @ninoCan
+enum: "enumera"
+  # ✅ @ninoCan
+explicit: "esplicito"
+  # ✅ @ninoCan
+export: "esporta"
+  # ✅ @ninoCan
+extern: "esterno"
+  # ✅ @ninoCan
+false: "falso"
+  # ✅ @ninoCan
+final: "finale"
+  # ✅ @ninoCan
+float: "mobile"
+  # ✅ @ninoCan
+for: "per"
+  # ✅ @ninoCan
+friend: "amico"
+  # ✅ @ninoCan
+goto: "vaiad"
+  # ✅ @ninoCan
+if: "se"
+  # ✅ @ninoCan
+inline: "allalinea"
+  # ✅ @ninoCan
+int: "intero"
+  # ✅ @ninoCan
+import: "importa"
+  # ✅ @ninoCan
+long: "lungo"
+  # ✅ @ninoCan
+module: "modulo"
+  # ✅ @ninoCan
+mutable: "cambiabile"
+  # ✅ @ninoCan
+namespace: "casellanome"
+  # ✅ @ninoCan
+new: "nuovo"
+  # ✅ @ninoCan
+noexcept: "noeccezione"
+  # ✅ @ninoCan
+not: "non"
+  # ✅ @ninoCan
+not_eq: "non_uguale"
+  # ✅ @ninoCan
+nullptr: "puntatorenullo"
+  # ✅ @ninoCan
+operator: "operatore"
+  # ✅ @ninoCan
+or: "od"
+  # ✅ @ninoCan
+or_eq: "od_uguale"
+  # ✅ @ninoCan
+override: ""
+  # 👀 @ninoCan
+private: "privato"
+  # ✅ @ninoCan
+protected: "protetto"
+  # ✅ @ninoCan
+public: "pubblico"
+  # ✅ @ninoCan
+register: "registro"
+  # ✅ @ninoCan
+reinterpret_cast: "reinterpreta_chiamata"
+  # ✅ @ninoCan
+requires: "richiedi"
+  # ✅ @ninoCan
+return: "restituisci"
+  # ✅ @ninoCan
+short: "corto"
+  # ✅ @ninoCan
+signed: "firmato"
+  # ✅ @ninoCan
+sizeof: "dimensionedi"
+  # ✅ @ninoCan
+static: "statico"
+  # ✅ @ninoCan
+static_assert: "afferamazione_statica"
+  # ✅ @ninoCan
+static_cast: "chiamata_statica"
+  # ✅ @ninoCan
+struct: "construtto"
+  # ✅ @ninoCan
+switch: "cambia"
+  # ✅ @ninoCan
+synchronized: "sincronizzato"
+  # ✅ @ninoCan
+template: "modello"
+  # ✅ @ninoCan
+this: "questo"
+  # ✅ @ninoCan
+thread_local: "filo_locale"
+  # ✅ @ninoCan
+throw: "lancia"
+  # ✅ @ninoCan
+transaction_safe: "transazione_sicura"
+  # ✅ @ninoCan
+transaction_safe_dynamic: "transizione_dinamica"
+  # ✅ @ninoCan
+true: "vero"
+  # ✅ @ninoCan
+try: "prova"
+  # ✅ @ninoCan
+typedef: "definiscitipo"
+  # ✅ @ninoCan
+typeid: "definisciid"
+  # ✅ @ninoCan
+typename: "tipodinome"
+  # ✅ @ninoCan
+union: "unione"
+  # ✅ @ninoCan
+unsigned: "anonimo"
+  # ✅ @ninoCan
+using: "usando"
+  # ✅ @ninoCan
+virtual: "virtuale"
+  # ✅ @ninoCan
+void: "vuoto"
+  # ✅ @ninoCan
+volatile: "volatile"
+  # ✅ @ninoCan
+wchar_t: "parola_t"
+  # ✅ @ninoCan
+while: "mentre"
+  # ✅ @ninoCan
+xor: "or_esclusivo"
+  # ✅ @ninoCan
+xor_eq: "uguale_esclusivo"
+  # ✅ @ninoCan
+
+# << Messaggi D'errore>>
+
+# ----------------------
+# |   LINGUAGGIO: C#     |
+# ----------------------
+# << Keywords >>
+abstract: "riassunto"
+  # ✅ @ninoCan
+add: "aggiungi"
+  # ✅ @ninoCan
+alias: "alias"
+  # ✅ @ninoCan
+as: "come"
+  # ✅ @ninoCan
+ascending: "crescendo"
+  # ✅ @ninoCan
+async: "asincrono"
+  # ✅ @ninoCan
+await: "aspetta"
+  # ✅ @ninoCan
+base: "base"
+  # ✅ @ninoCan
+bool: "boleano"
+  # ✅ @ninoCan
+break: "interrompi"
+  # ✅ @ninoCan
+byte: "byte"
+  # ✅ @ninoCan
+case: "caso"
+  # ✅ @ninoCan
+catch: "cattura"
+  # ✅ @ninoCan
+char: "carattere"
+  # ✅ @ninoCan
+checked: "controllato"
+  # ✅ @ninoCan
+class: "classe"
+  # ✅ @ninoCan
+const: "costante"
+  # ✅ @ninoCan
+continue: "continua"
+  # ✅ @ninoCan
+decimal: "decimale"
+  # ✅ @ninoCan
+default: "default"
+  # ✅ @ninoCan
+delegate: "delega"
+  # ✅ @ninoCan
+descending: "scendendo"
+  # ✅ @ninoCan
+do: "fai"
+  # ✅ @ninoCan
+double: "doppio"
+  # ✅ @ninoCan
+dynamic: "dinamico"
+  # ✅ @ninoCan
+else: "altrimenti"
+  # ✅ @ninoCan
+enum: "enumera"
+  # ✅ @ninoCan
+event: "evento"
+  # ✅ @ninoCan
+explicit: "esplicito"
+  # ✅ @ninoCan
+extern: "esterno"
+  # ✅ @ninoCan
+false: "falso"
+  # ✅ @ninoCan
+finally: "infine"
+  # ✅ @ninoCan
+fixed: "fisso"
+  # ✅ @ninoCan
+float: "mobile"
+  # ✅ @ninoCan
+for: "per"
+  # ✅ @ninoCan
+foreach: "perogni"
+  # ✅ @ninoCan
+from: "da"
+  # ✅ @ninoCan
+get: "prendi"
+  # ✅ @ninoCan
+global: "globale"
+  # ✅ @ninoCan
+goto: "vaiad"
+  # ✅ @ninoCan
+group: "gruppo"
+  # ✅ @ninoCan
+if: "se"
+  # ✅ @ninoCan
+implicit: "implicito"
+  # ✅ @ninoCan
+in: "in"
+  # ✅ @ninoCan
+int: "intero"
+  # ✅ @ninoCan
+interface: "interfaccia"
+  # ✅ @ninoCan
+internal: "interno"
+  # ✅ @ninoCan
+into: "dentro"
+  # ✅ @ninoCan
+is: "essere"
+  # ✅ @ninoCan
+join: "unisci"
+  # ✅ @ninoCan
+let: "sia"
+  # ✅ @ninoCan
+lock: "blocca"
+  # ✅ @ninoCan
+long: "lungo"
+  # ✅ @ninoCan
+namespace: "casellanome"
+  # ✅ @ninoCan
+new: "nuovo"
+  # ✅ @ninoCan
+null: "nullo"
+  # ✅ @ninoCan
+object: "oggetto"
+  # ✅ @ninoCan
+operator: "operatore"
+  # ✅ @ninoCan
+orderby: "ordinaper"
+  # ✅ @ninoCan
+out: "fuori"
+  # ✅ @ninoCan
+override: "scavalca"
+  # ✅ @ninoCan
+params: "parametri"
+  # ✅ @ninoCan
+partial: "parziale"
+  # ✅ @ninoCan
+private: "privato"
+  # ✅ @ninoCan
+protected: "protetto"
+  # ✅ @ninoCan
+public: "pubblico"
+  # ✅ @ninoCan
+readonly: "solalettura"
+  # ✅ @ninoCan
+ref: "riferisciad"
+  # ✅ @ninoCan
+remove: "rimuovi"
+  # ✅ @ninoCan
+return: "restituisci"
+  # ✅ @ninoCan
+sbyte: "sbyte"
+  # ✅ @ninoCan
+sealed: "chiuso"
+  # ✅ @ninoCan
+select: "seleziona"
+  # ✅ @ninoCan
+set: "imposta"
+  # ✅ @ninoCan
+short: "corto"
+  # ✅ @ninoCan
+sizeof: "dimensionedi"
+  # ✅ @ninoCan
+stackalloc: "allocastack"
+  # ✅ @ninoCan
+static: "statico"
+  # ✅ @ninoCan
+string: "stringa"
+  # ✅ @ninoCan
+struct: "construtto"
+  # ✅ @ninoCan
+switch: "cambia"
+  # ✅ @ninoCan
+this: "questo"
+  # ✅ @ninoCan
+throw: "getta"
+  # ✅ @ninoCan
+true: "vero"
+  # ✅ @ninoCan
+try: "prova"
+  # ✅ @ninoCan
+typeof: "tipodi"
+  # ✅ @ninoCan
+uint: "uintero"
+  # ✅ @ninoCan
+ulong: "ulungo"
+  # ✅ @ninoCan
+unchecked: "scoperto"
+  # ✅ @ninoCan
+unsafe: "insicuro"
+  # ✅ @ninoCan
+ushort: "ucorto"
+  # ✅ @ninoCan
+using: "usando"
+  # ✅ @ninoCan
+value: "valore"
+  # ✅ @ninoCan
+var: "variabile"
+  # ✅ @ninoCan
+virtual: "virtuale"
+  # ✅ @ninoCan
+void: "vuoto"
+  # ✅ @ninoCan
+volatile: "volatile"
+  # ✅ @ninoCan
+where: "dove"
+  # ✅ @ninoCan
+while: "mentre"
+  # ✅ @ninoCan
+yield: "comporta"
+  # ✅ @ninoCan
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LINGUAGGIO: PYTHON  |
+# ----------------------
+# << Parole chiave >>
+  False: "Falso"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  None: "Nessuno"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  True: "Vero"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  and: "ed"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni The right traduction is 'e' we use 'ed' before the words that start with a vowel
+    # ❓ @sime1 this should indeed be 'e'. Using 'e' before words that start with a vowel is common, using 'ed' before words that start with a consonant is not.
+    # ❓ @Girgetto Another possible translation could be 'anche'
+    # ❓ @ffex I think the correct word is 'e'. 'ed' it is used when the follow word start with vowel.
+  as: "come"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  assert: "asserisci"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni The traduction is right, but for me it doesn't mean the same thing, I think it's better to not traduce it
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ❓ @ffex In italian this it is not clear with the meaning of "assert". maybe we can prove with "afferma" or no traducted 
+  async: "asincrono"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  await: "attendi"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  break: "interrompi"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  class: "classe"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  continue: "continua"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  def: "def"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  del: "canc"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  elif: "altrose"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I would translate it with 'altrimenti se'
+    # ❓ @sime1 'altrimentise' makes more sense than 'altrose'
+    # ❓ @Girgetto 'altrimentise' sounds better
+    # ❓ @ffex 'altrimentise' it is better
+  else: "altrimenti"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I would translate it with 'altrimenti'
+    # ❓ @sime1 I think 'altrimenti' is the right translation
+    # ✅ @Girgetto
+    # ✅ @ffex
+  except: "eccetto"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  finally: "finalmente"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I0 would translate it with 'infine'
+    # ❓ @sime1 I agree with 'infine'
+    # ✅ @Girgetto
+    # ❓ @ffex I agree with 'infine'
+  for: "per"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  from: "da"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  global:  "globale"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  if: "se"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  import: "importa"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  in: "in"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  is: "esiste"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I would translate it with 'é'
+    # ❓ @sime1 'è' makes more sense
+    # ✅ @Girgetto
+    # ❓ @ffex it's better "è"
+  lambda: "lambda"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  nonlocal: "nonlocale"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  not: "non"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  or: "od"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni The right traduction is 'o' we use 'od' before the words that start with a vowel
+    # ❓ @sime1 same thing as the 'ed'/'e'
+    # ❓ @Girgetto Another possible translation could be 'oppure'
+    # ❓ @ffex it is better 'o'. it's like "e/ed"
+  pass: "salta"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  raise: "alza"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ❓ @sime1 I think when talking about exceptions we mostly use "solleva" instead of "alza"; they are synonims tho, so maybe "alza" is ok
+    # ✅ @Girgetto
+    # ❓ @ffex The traslation is correct but I think that in the context of Python the meaning is 'raise an exception', I traduct it with 'lancia una eccezione'. So maybe 'lancia' is better?
+  return: "restituisci"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  try: "prova"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  while: "mentre"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  with: "con"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  yield: ""
+    # 👀 @ninoCan
+    # 🤔 @GiacomoPignoni
+    # ❓ @sime1 I think we could use 'cedi' or 'produci'
+    # ❓ @Girgetto 'produci' could be a good translation
+    # ❓ @ffex 'produci' sound's good
+
+# << Built-In Functions >>
+
+  abs: "modulo"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  all: "tutti"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  any: "ogni"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  ascii: "ascii"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  bin: "binario"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  bool: "booleano"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1 (updated spelling) this would be 'booleano', I think 'boleano' just a typo
+    # ✅ @Girgetto
+    # ✅ @ffex
+  breakpoint: "rompise"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I would translate it with 'interruzione'
+    # ✅ @sime1 I would not translate this
+    # ❓ @Girgetto This is a more literal translation but it sounds good to me I would suggest 'puntodirottura'
+    # ❓ @ffex it is better without translation or maybe with 'puntodiinterruzione'
+  bytearray: "byteschiera"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I would translate it with 'sequenza di byte', but I think it sounds good as it is
+    # 🤔 @sime1 I'm not sure we should translate this, it does not sound natural
+    # ❓ @Girgetto I would suggest 'listadibyte' or 'sequenzadibyte''
+    # ❓ @ffex it is better without translation or maybe with 'vettoredibyte'
+  bytes: "bytes"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  callable: "chiamabile"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  chr: "car"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  classmethod: "metodoclasse"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  compile: "compila"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  complex: "complesso"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  delattr: "cancattr"
+  # I think cancattr is fine
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni It's right but it doesn't sound good in Italian
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  dict: "dizionario"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  dir: "cartella"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  divmod: "quozienteresto"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  enumerate: "enumera"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  eval: "valuta"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  exec: "esegui"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  filter: "filtra"
+    # ✅ @ninoCan "filra"
+    # ✅ @GiacomoPignoni (update spelling) It's written wrong, it's 'filtra'
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  float: "mobile"
+    # ✅ @ninoCan
+    # 🤔 @GiacomoPignoni
+    # 🤔 @sime1 we could use "virgolamobile" but I think it's best not to translate this
+    # ❓ @Girgetto 'flotante' or 'virgolamobile' sounds better
+    # ❓ @ffex 'virgolamobile' sounds better
+  format: "formato"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I think 'formatta' it's better
+    # ❓ @sime1 agree with 'formatta'
+    # ❓ @Girgetto
+    # ❓ @ffex agree with 'formatta'
+  frozenset: "insiemecongelato"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  getattr: "ottieniattr"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  globals: "globali"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  hasattr: "possiedeattr"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  hash: "hash"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  help: "aiuto"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  hex: "esa"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I think 'esadecimale' it's better
+    # ✅ @sime1 I think 'esadecimale' is too long compared to 'hex', maybe 'esadec'
+    # ✅ @Girgetto
+    # ✅ @ffex
+  id: "id"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  input: "input"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  int: "intero"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # 🤔 @sime1 'int' is short for 'integer', but works for 'intero' as well so maybe we should not translate it
+    # ✅ @Girgetto
+    # ✅ @ffex
+  isinstance: "esisteinistanza"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  issubclass: "inclasse"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  iter: "itera"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  len: "lunghezza"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  list: "lista"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  locals: "locali"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  map: "mappa"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  max: "massimo"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  memoryview: "inmemoria"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # 🤔 @sime1 not sure we should translate this
+    # ✅ @Girgetto
+    # ✅ @ffex
+  min: "minimo"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  next: "seguente"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  object: "oggetto"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  oct: "ottava"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ❓ @sime1 should be 'ottale', 'ottava' does not mean the same thing
+    # 👀 @Girgetto
+    # ❓ @ffex agree with "ottale"
+  open: "apri"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  ord: "ordine"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  pow: "potenza"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  print: "stampa"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  property: "proprieta"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ❓ @sime1 should be 'proprietà'
+    # ✅ @Girgetto
+    # ✅ @ffex
+  range: "catena"
+    # ✅ @ninoCan
+    # 🤔 @GiacomoPignoni
+    # ❓ @sime1 the closest translation is "intervallo"
+    # ❓ @Girgetto should be 'intervallo'
+    # ❓ @ffex agree with 'intervallo'
+  repr: "rappresenta"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  reversed: "invertito"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  round: "arrotonda"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  set: "insieme"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni We aslo use 'set' in Italian, but the traduction is right
+    # 🤔 @sime1 I would not translate this
+    # ✅ @Girgetto
+    # ❓ @ffex it is 'imposta' when the meaning is 'set a variable' for example. it is 'insieme' when the meaning is 'a data set' for example. Agree with not traslate it.
+  setattr: "impostaattr"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  slice: "affetta"
+    # ✅ @ninoCan
+    # ❓ @GiacomoPignoni I think 'spezza' it's better
+    # ❓ @sime1 maybe 'taglia'
+    # ✅ @Girgetto
+    # ❓ @ffex agree with 'taglia'
+  sorted: "ordinato"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  staticmethod: "metodostatico"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  str: "stringa"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # 🤔 @sime1 same as 'int', I would leave 'str'
+    # ✅ @Girgetto
+    # ✅ @ffex
+  sum: "somma"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  super: "contiene"
+    # ✅ @ninoCan
+    # 🤔 @GiacomoPignoni
+    # ❓ @sime1 'contiene' does not mean the same thing, I would maybe use 'superiore' or leave it 'super'
+    # ❓ @Girgetto Conceptually is correct, but is not a literal translation, I would leave 'super'
+    # ❓ @ffex better not traslate. 'super' is used in italian
+  tuple: "tupla"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  type: "tipo"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  vars: "variabili"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ✅ @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+  zip: "comprimi"
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # ❓ @sime1 The best translation I can think of is 'cerniera'. I think 'comprimi' is misleading, so I would rather leave 'zip' as is
+    # ❓ @Girgetto Conceptually is correct, but is not a literal translation, I would leave 'zip'
+    # ✅ @ffex
+  __import__: "__importa__" ✅✅
+    # ✅ @ninoCan
+    # ✅ @GiacomoPignoni
+    # 👀 @sime1
+    # ✅ @Girgetto
+    # ✅ @ffex
+# << Messaggi d'errore >>
+
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/ml.yml
+++ b/locale/ml.yml
@@ -1,0 +1,1898 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "ml"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "കേസ്"
+ # ✅ @varghesejose2020
+do: "ചെയ്യുക"
+ # ✅ @varghesejose2020
+done: "ചെയ്തു"
+ # ✅ @varghesejose2020
+elif: "എലിഫ്"
+ # ✅ @varghesejose2020
+else: "വേറെ"
+ # ✅ @varghesejose2020
+esac: "ഈസക്"
+ # ✅ @varghesejose2020
+fi: "ഫൈ"
+ # ✅ @varghesejose2020
+for: "വേണ്ടി"
+ # ✅ @varghesejose2020
+function: "പ്രവർത്തനം"
+ # ✅ @varghesejose2020
+if: "എങ്കിൽ"
+ # ✅ @varghesejose2020
+in: "ഭാഗമായ"
+ # ✅ @varghesejose2020
+select: "തിരഞ്ഞെടുക്കുക"
+ # ✅ @varghesejose2020
+then: "പിന്നെ"
+ # ✅ @varghesejose2020
+time: "സമയം"
+ # ✅ @varghesejose2020
+until: "വരുവോളം"
+ # ✅ @varghesejose2020
+while: "സമയത്ത്"
+ # ✅ @varghesejose2020
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "തെറ്റ്"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  None: "ഒന്നുമില്ല"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  True: "സത്യം"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  and: "ഒപ്പം"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  as: "ആയി"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  assert: "ഉറപ്പിക്കുക"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  async: "അസിങ്ക്"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  await: "പതീക്ഷിച്ചിരിക്കുക"
+    # ✅ @sanjay-kv
+    # ❓ @varghesejose2020  "പ്രതീക്ഷിച്ചിരിക്കുക"
+  break: "ഇടവേള"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  class: "ക്ലാസ്"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  continue: "തുടരുക"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  def: "ഡിഎഫ്"
+    # ✅ @sanjay-kv
+  del: "ഇല്ലാതാക്കുക"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  elif: "എലിഫ"
+    # ✅ @sanjay-kv
+    # ❓ @varghesejose2020  "എലിഫ്"
+  else: "വേറെ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  except: "പ്രതീക്ഷിക്കുന്നു"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  finally: "ഒടുവിൽ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  for: "വേണ്ടി"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  from: "മുതൽ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  global:  "ഗ്ലോബൽ "
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  if: "എങ്കിൽ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  import: "ഇറക്കുമതി"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  in: "ഇൻ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  is: "ആണ്"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  lambda: "ലാമ്പടാ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  nonlocal: "നോൺലോക്കൽ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  not: "അല്ല"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  or: "അഥവാ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  pass: "പാസ്"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  raise: "ഉയർത്തുക"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  return: "മടക്കം"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  try: "ശ്രമിക്കുക"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  while: "അതേസമയം"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  with: "കൂടെ"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+  yield: "വരുമാനം"
+    # ✅ @sanjay-kv
+    # ✅ @varghesejose2020
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/ne.yml
+++ b/locale/ne.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: ""
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "असत्य"
+  None: "खाली" # ? Another suggestion: कुनै हैन
+  True: "सत्य"
+  and: "र"
+  as: "जस्तो"
+  assert: "घोषणा गर्नु"
+  async: "एकै समयमा"
+  await: "पर्खनु"
+  break: "भाच्नु"
+  class: "वर्ग"
+  continue: "जारी राख्नु"
+  def: "परिभाषा"
+  del: "हटाउनु"
+  elif: "अन्यथा भने"
+  else: "अर्को"
+  except: "बाहेक"
+  finally: "अन्तमा"
+  for: "लागी"
+  from: "बाट"
+  global:  "वैश्विक"
+  if: "यदी"
+  import: "आयात गर्नु"
+  in: "भित्र"
+  is: "हो"
+  lambda: "लम्ब्डा" # ?
+  nonlocal: "गैर स्थानीय"
+  not: "हैन"
+  or: "वा"
+  pass: "पारित गर्नु"
+  raise: "उठाउनु"
+  return: "फर्किनु"
+  try: "प्रयास गर्नु"
+  while: "जब"
+  with: "साथ"
+  yield: "पैदा गर्नु"
+
+# << Built-In Functions >>
+
+  abs: "पूर्ण"
+  all: "सम्पूर्ण"
+  any: "कुनै"
+  ascii: "ascii" # ?
+  bin: "बाइनरी" # ?
+  bool: "बूल" # ?
+  breakpoint: "विराम बिंदु"
+  bytearray: "बाइट अरे" # ?
+  bytes: "बाइट्स" # ?
+  callable: "बोलाउन योग्य"
+  chr: "अक्षर" # ?
+  classmethod: "वर्ग विधि"
+  compile: "सन्कलन गर्नु"
+  complex: "जटिल"
+  delattr: "विशेषता हटाउनु"
+  dict: "कोष"
+  dir: "निर्देशिका"
+  divmod: "भाग शेष"
+  enumerate: "गिन्ती गर्नु"
+  eval: "मूल्यांकन गर्नु"
+  exec: "कार्यान्वन गर्नु"
+  filter: "छान्नु"
+  float: "फ्लोट" # ?
+  format: "स्वरुप"
+  frozenset: "फ्रोजन सेट" # ?
+  getattr: "विशेषता पाउनु"
+  globals: "विश्वव्यापी"
+  hasattr: "विशेषता हुनु"
+  hash: "ह्यास" # ?
+  help: "सहयोग"
+  hex: "हेक्स" # ?
+  id: "आईडी" # ?
+  input: "निवेश"
+  int: "पूर्णांक"
+  isinstance: "उदाहरण हो"
+  issubclass: "उपवर्ग हो"
+  iter: "पुनरावृत्ति गर्नु"
+  len: "लम्बाइ"
+  list: "सूची"
+  locals: "स्थानिय"
+  map: "नक्शा"
+  max: "अधिकतम"
+  memoryview: "स्मृति दृश्य"
+  min: "न्यूनतम"
+  next: "अर्को"
+  object: "वस्तु"
+  oct: "अष्ट" # ?
+  open: "खोल्नु"
+  ord: "ऑर्ड" # ?
+  pow: "घाता" # ?
+  print: "छाप्नु"
+  property: "सम्पत्ति"
+  range: "दायरा"
+  repr: "प्रतिनिधित्व"
+  reversed: "उल्टो"
+  round: "गोलो"
+  set: "समूह"
+  setattr: "विशेषता राख्नु"
+  slice: "काट्नु"
+  sorted: "क्रमबद्ध"
+  staticmethod: "स्थिर विधि"
+  str: "स्तृङ" # ?
+  sum: "योगफल"
+  super: "उत्तम"
+  tuple: "टपल" # ?
+  type: "प्रकार"
+  vars: "अस्थिर"
+  zip: "ज़िप" # ?
+  __import__: "__आयात__"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/nl.yml
+++ b/locale/nl.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "nl"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "NOTITIE"
+  INFO: "INFORMATIE"
+  IDEA: "IDEE"
+  DEBUG: "DEBUG"
+  REMOVE: "VERWIJDER"
+  OPTIMIZE: "OPTIMALISEER"
+  REVIEW: "INSPECTEREN"
+  HACK: ""
+  UNDONE: "ONGEDAAN GEMAAKT"
+  TODO: "TE DOEN"
+  REFACTOR: "HERSTRUCTUREREN"
+  DEPRECATED: "VEROUDERD"
+  TASK: "TAAK"
+  CHGME: ""
+  NOTREACHED: "NIET GEHAALD"
+  WTF: ""
+  BUG: "BUG"
+  ERROR: "FOUT"
+  OMG: "OH MIJN GOD"
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: "WAARSCHUWING"
+  WARN: ""
+  BROKEN: "KAPOT"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Niet waar"
+  None: "Geen"
+  True: "Waar"
+  and: "en"
+  as: "als"
+  assert: "beweer"
+  async: "asynchroon"
+  await: "wachten"
+  break: "afbreken"
+  class: "klasse"
+  continue: "doorgaan"
+  def: "def"
+  del: "del"
+  elif: "anders als"
+  else: "anders"
+  except: "verwacht"
+  finally: "eindelijk"
+  for: "voor"
+  from: "van"
+  global:  "globaal"
+  if: "als"
+  import: "importeer"
+  in: "in"
+  is: "is"
+  lambda: "lambda"
+  nonlocal: "niet lokaal"
+  not: "niet"
+  or: "of"
+  pass: "laat slagen"
+  raise: "roep op"
+  return: "geef terug"
+  try: "probeer"
+  while: "terwijl"
+  with: "met"
+  yield: "geef terug"
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/pl.yml
+++ b/locale/pl.yml
@@ -1,0 +1,1839 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "pl"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "NOTATKA"
+  INFO: "INFORMACJA"
+  IDEA: "IDEA"
+  DEBUG: "DEBUG"
+  REMOVE: "USUNĄĆ"
+  OPTIMIZE: "OPTYMALIZACJA"
+  REVIEW: "OCENIAĆ"
+  HACK: "HAKOWAĆ"
+  UNDONE: "NIEZROBIONE"
+  TODO: "DOZROBIENIA"
+  REFACTOR: "ZMIENIAĆ"
+  DEPRECATED: ""
+  TASK: "ZADANIE"
+  CHGME: "CHGME"
+  NOTREACHED: "NIEOSIĄGNIĘTY"
+  WTF: "WTF"
+  BUG: "PROBLEM"
+  ERROR: "BŁĄD"
+  OMG: "OMG"
+  ERR: "ERR"
+  OMFGRLY: "OMFGRLY"
+  WARNING: "OSTRZEŻENIE"
+  WARN: "OSTRZEGAĆ"
+  BROKEN: "ZEPSUTY"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: "abstrakcyjny"
+  codata: "wsółdane"
+  coinductive: "koindukcyjny"
+  constructor: "kkonstraktor"
+  data: "data"
+  do: "zrobić"
+  eta-equality: "współprzewidziany"
+  field: "pole"
+  forall: "dlakażdego"
+  hiding: "ukrywać"
+  import: "importować"
+  in: "w"
+  inductive: "induktywny"
+  infix: "wzrostek"
+  infixl: "wzrostekl"
+  infixr: "wzrostekr"
+  instance: "przykład"
+  let: "pozwolić"
+  macro: "makro"
+  module: "moduł"
+  mutual: "wspólny"
+  no-eta-equality: ""
+  open: "otwarty"
+  overlap: "nakładaćsię"
+  pattern: "wzór"
+  postulate: "postulować"
+  primitive: "prymitywny"
+  private: "prywatny"
+  public: "publiczny"
+  quote: "cytować"
+  quoteContext: "przytaczaćKontekst"
+  quoteGoal: "przytaczaćCel"
+  quoteTerm: "przytaczaćSłowo"
+  record: "rekord"
+  renaming: "przemianować"
+  rewrite: "przepisać"
+  Set: "Zbiór" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "składnia"
+  tactic: "taktyka"
+  unquote: "zamykaćCudzysłów"
+  unquoteDecl: "zamykaćDeklarację"
+  unquoteDef: "zamykaćDefinicje"
+  using: "używać"
+  where: "gdzie"
+  with: "z"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "zrób" # (part of do-while statement)
+while: "kiedy"
+for: "dla"
+if: "jeśli" # (part of if-else statement)
+else: "inaczej" # (part of if-else statement)
+switch: "zmień"
+break: "złam" # (part of the switch statement or for/while statements)
+case: "przypadek" # (part of the switch statement)
+continue: "kontynuuj" # (part of for/while statements)
+default: "domyślny" # (part of switch statement)
+function: "funkcja"
+procedure: "procedura"
+return: "zwróć"
+local: "lokalny"
+global: "globalny"
+static: "statyczny"
+typeof: "przykład"
+NOT: "NIE"
+AND: "I"
+OR: "LUB"
+Null: "NIEWAŻNY"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "przypadek"
+do: "zrób"
+done: "zrobione"
+elif: "inaczej jeśli"
+else: "inaczej"
+esac: "esac"
+fi: "fi"
+for: "dla"
+function: "funkcja"
+if: "jeśli"
+in: "w"
+select: "wybierz"
+then: "wtedy"
+time: "czas"
+until: "dopóki"
+while: "kiedy"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "auto"
+double: "dwucyfrowa"
+int: "całkowita"
+struct: "strukt"
+break: "złam"
+else: "inaczej"
+long: "długa"
+switch: "zmień"
+case: "przypadek"
+enum: "enumerator"
+register: "rejestr"
+typedef: "typDom"
+char: "litera"
+extern: "zewnętrzny"
+return: "zwróć"
+union: "unia"
+const: "stała"
+float: "płynna"
+short: "krótki"
+unsigned: "niepodpisany"
+continue: "kontynuuj"
+for: "dla"
+signed: "podpisany"
+void: "nieważny"
+default: "domyślny"
+goto: "idźDo"
+sizeof: "rozmiaru"
+volatile: "złamać"
+do: "zrób"
+if: "jeśli"
+static: "statyczny"
+while: "jeśli"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: "abstrakcyjna"
+add: "dodaj"
+alias: "alias"
+as: "jako"
+ascending: "rosnąco"
+async: "asynchronicznie"
+await: "oczekuj"
+base: "bazowy"
+bool: "boolowski"
+break: "przerwij"
+byte: "bajt"
+case: "przypadek"
+catch: "złap"
+char: "znak"
+checked: "sprawdzona"
+class: "klasa"
+const: "stała"
+continue: "kontynuuj"
+decimal: "dziesiętny"
+default: "domyślna"
+delegate: "delegowana"
+descending: "malejąco"
+do: "rób"
+double: "podwójna"
+dynamic: "dynamiczna"
+else: "inaczej"
+enum: "enumerator"
+event: "wydarzenie"
+explicit: "wyraźna"
+extern: "zewnętrzna"
+false: "fałsz"
+finally: "wreszcie"
+fixed: "ustalona"
+float: "zmiennoprzecinkowa"
+for: "dla"
+foreach: "dlakażdego"
+from: "od"
+get: "weź"
+global: "globalna"
+goto: "idźdo"
+group: "grupuj"
+if: "jeśli"
+implicit: "rzekomo"
+in: "jest"
+int: "liczba"
+interface: "interfejs"
+internal: "wewnętrzna"
+into: "w"
+is: "jest"
+join: "połącz"
+let: "niech"
+lock: "zablokuj"
+long: "długa"
+namespace: "przestrzeń"
+new: "nowa"
+null: "nic"
+object: "obiekt"
+operator: "operator"
+orderby: "uporządkuj"
+out: "wyprowadź"
+override: "przeciąż"
+params: "parametry"
+partial: "częściowa"
+private: "prywatna"
+protected: "chroniona"
+public: "publiczna"
+readonly: "odczytywalna"
+ref: "referencja"
+remove: "usuń"
+return: "zwróć"
+sbyte: "sbajt"
+sealed: "zamknięta"
+select: "wybierz"
+set: "ustaw"
+short: "krótka"
+sizeof: "rozmiar"
+stackalloc: "alokujstos"
+static: "statyczna"
+string: "wyraz"
+struct: "struktura"
+switch: "zmieniaj"
+this: "to"
+throw: "rzuć"
+true: "prawda"
+try: "próbuj"
+typeof: "typ"
+uint: "dodatnia"
+ulong: "dodatniadługa"
+unchecked: "niesprawdzona"
+unsafe: "niebezpieczna"
+ushort: "dodatniakrótka"
+using: "używając"
+value: "wartość"
+var: "zmienna"
+virtual: "wirtualna"
+void: "pusta"
+volatile: "ulotna"
+where: "gdzie"
+while: "dopóki"
+yield: "zwracaj"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: "abstrakcyjna"
+continue: "kontynuuj"
+for: "dla"
+new: "nowa"
+switch: "zmień"
+assert: "weryfikuj"
+default: "domyślna"
+goto: "idźdo"
+package: "pakiet"
+synchronized: "synchronizowana"
+boolean: "boolowska"
+do: "rób"
+if: "jeśli"
+private: "prywatna"
+this: "to"
+break: "złam"
+double: "podwójna"
+implements: "implementuje"
+protected: "chroniona"
+throw: "rzuć"
+byte: "bajt"
+else: "inaczej"
+import: "importuj"
+public: "publiczna"
+throws: "rzuca"
+case: "przypadek"
+enum: "enumerator"
+instanceof: "instancja"
+return: "zwróć"
+transient: "ulotna"
+catch: "złap"
+extends: "roszszerza"
+int: "liczba"
+short: "krótka_liczba"
+try: "próbuj"
+char: "znak"
+final: "ostateczna"
+interface: "interfejs"
+static: "statyczny"
+void: "pusty"
+class: "klasa"
+finally: "wreszcie"
+long: "długa"
+strictfp: "ograniczona"
+volatile: "ulotna"
+const: "stała"
+float: "zmiennoprzecinkowa"
+native: "natywna"
+super: "nadrzędna"
+while: "dopóki"
+_: "_" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: "argumenty"
+await: "oczekuj"
+break: "przerwij"
+case: "przypadek"
+catch: "złap"
+class: "klasa"
+const: "stała"
+continue: "kontynuuj"
+debugger: "debugger"
+default: "domyślna"
+delete: "usuń"
+do: "rób"
+else: "inaczej"
+enum: "wyliczenie"
+eval: "oblicz"
+export: "eksportuj"
+extends: "rozszerza"
+false: "fałsz"
+finally: "wreszcie"
+for: "dla"
+from: "od"
+function: "funkcja"
+if: "jeżeli"
+implements: "implementuje"
+import: "importuj"
+in: "w"
+instanceof: "instancja"
+interface: "interfejs"
+let: "niech"
+new: "nowy"
+null: "nic"
+package: "pakiet"
+private: "prywatna"
+protected: "chroniona"
+public: "publiczna"
+return: "zwróć"
+static: "statyczna"
+super: "super"
+switch: "zmieniaj"
+this: "to"
+throw: "rzuć"
+true: "prawda"
+try: "próbuj"
+typeof: "typ"
+var: "zmienna"
+void: "pusty"
+while: "dopóki"
+with: "z"
+yield: "zwróc"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+#
+# Things that definitely a second look by someone have 2ndOPINION on the same line as the word that needs looking at.
+#
+# Some notes:
+#
+# 1) Would it be better to substitute the Polish letters
+#    with their normal Latin variations to ease typing
+#    for the end user?
+#
+#    Examples:
+#        oczekój -> oczekoj
+#        usuń -> usun
+#
+# 2) So far I've been writing in tense like as if the author
+#    is talking to the script & telling the code to do stuff.
+#    I think it makes sense to do it like that but would like
+#    someone else's opinion on this.
+#
+
+  False: "Nieprawda" # Fałsz? # ❓ I Would go with Fałsz ❓ "fałsz" sounds better ❓ 'fałsz' definitely sounds more natural
+  None: "Nic" # ✅✅✅
+  True: "Prawda" # ✅✅✅
+  and: "i" #❓ I would use "oraz" because i is often used as variable for iteration ❓ "oraz" would be better ❓ 'oraz' sounds better
+  as: "jako" # jak? ✅ 'jako' is good ✅ "jako" is fine ✅
+  assert: "zapewnij" # zapewniać ✅ 'zapewnij' is good ✅ "zapewnij" is fine ✅
+  async: "asynchronicznie" # Probably best to keep as "async". ✅ both seem good ✅ "asynchronicznie" is fine but quite long, but I think it might be more understandable this way✅ the translation is correct, although i'd keep it as 'async'
+  await: "oczekój" # poczekaj? oczekiwać? ❓ it's a grammar error, should be: 'oczekuj' ❓ it should be "oczekuj", but apart from that it's fine ❓ it's 'oczekuj'
+  break: "przerwij" # przerwać? ✅ is good ✅ "przerwij" is fine ✅
+  class: "klasa" # ✅✅✅
+  continue: "kontynuuj" # ✅✅✅
+  def: "definicja" # Probably best to keep as "def" ✅ both are good ✅ I think that "definicja" is better and easier to understand, especially for total newbies, even though it's longer ❓ 'definicja' sounds good, although python's 'def' is an abbreviation of 'define'. 'define' in polish is 'zdefiniuj' 
+  del: "usuń" # kasuj? ✅ 'usuń' is good ✅ "usuń" is fine ✅
+  elif: "inaczejjeśli" # inaczej_jeśli?   Abbreviation: injeśli? [2ndOPINION] ✅ 'inaczejjeśli ❓considering my change below I suggest "w_przeciwnym_razie_jeżeli" ✅ 'inaczejjeśli' sounds pretty straightforward and i'd leave it as is
+  else: "inaczej" # ✅ ❓ I'd go with "w_przeciwnym_razie", it's way longer but sounds more appropriate ✅ 
+  except: "wyjątek" # ✅✅✅
+  finally: "wreszcie" # ostatecznie? ✅ 'wreszcie' is good ❓ I'd also consider: "w_końcu" ❓ in this context, it'd be 'ostatecznie'
+  for: "na" # za? ❓ should be: 'dla' ❓ "dla" is more appropriate ❓ i agree on 'dla'
+  from: "z" # od? ✅ 'z' is good ✅ "z" is fine ✅
+  global:  "globalna" # ✅✅✅
+  if: "jeśli" # jeżeli? ✅ both are good ❓ "jeżeli" sounds better ✅ 'jeśli' sounds better imho, personal preference. both are understandable 
+  import: "importuj" # importować? ✅ 'importuj' is good ❓ I think "zaimportuj" might be better ✅ 'importuj' sounds best
+  in: "w" # we? ✅ 'w' is good ✅ "w" is fine ✅
+  is: "jest" # ✅✅✅
+  lambda: "lambda" # ✅✅✅
+  nonlocal: "nielokalna" # nie_lokalna? ✅ 'nielokalna' is good ✅✅
+  not: "nie" # ✅✅✅
+  or: "albo" # ✅✅✅
+  pass: "przejdź" # ✅✅✅
+  raise: "zgłoś" # ✅✅✅
+  return: "zwróć" # ✅✅✅
+  try: "spróbuj" # ✅✅✅
+  while: "podczas" # ❓ should be 'dopóki' or 'gdy' ❓ "dopóki" would be better ❓ i agree on 'dopóki'
+  with: "przy" # Can't think of any other word that makes sense & doesn't clash with "from". [2ndOPINION] # ✅ ❓ I'd go with "wraz" ❓ i'd go with 'wraz' / 'wraz_z'
+  yield: "wydobywaj" # ❓ 'zwracaj' should be better although it does conflict with 'return' ❓ not sure how to translate, it's similar to return but then it would collide ❓ I think 'dostarcz' could work pretty well to avoid the clash with 'return'
+
+# << Built-In Functions >>
+
+  abs: "wartość_całkowita" # To avoid clash with "int" the "wartość_" & "liczba_" (for "int") unless there are better suggestions? [2dOPInNION] ❓ I think it should be "wartość_bezwzględna"? ❓ agreed, should be 'wartość_bezwzględna', maybe even just 'bezwzględna' to make it shorter
+  all: "wszystko" # ✅✅
+  any: "jakiekolwiek" # ❓ "jakikolwiek" might be better ❓ 'jakikolwiek' would work better in this case
+  ascii: "ascii" # ✅✅
+  bin: "binarny" # ✅✅
+  bool: "bool" # boolowska? zerojedynkowa? 🤔 not sure if there is any translation🤔 we use 'boolean' in polish so i'd leave it 
+  breakpoint: "punkt_przerwania" # ✅✅
+  bytearray: "tablica_bajtów" # szyk_bajtów? ✅ "tablica_bajtów" is fine ❓ i'd argue that 'szereg_bajtów' would be better. 'tablica' means 'table/board' and i feel like it shouldn't be used in this context
+  bytes: "bajty" # ✅✅
+  callable: "wywoływalne"# ✅✅
+  chr: "znak" # litera? ✅ znak is fine ✅
+  classmethod: "metoda_klasowa" # metodaklasowa klasowametoda? klasowa_metoda? ✅ "metoda_klasowa" is fine✅
+  compile: "skompiluj" # ✅✅
+  complex: "kompleksowa" # kompleksowa_analiza? ❓ not sure about this one ❓ it's 'zespolona' or 'liczba_zespolona'
+  delattr: "usuń_atrybut" # usuńatrybut? ✅ I think that writing with floor will make the code look cleaner so I'd leave it as it is✅
+  dict: "słownik" # ✅✅
+  dir: "katalog" # informator? ✅ "katalog" is fine✅ 'katalog' sounds better
+  divmod: "dzielmod" # ❓ "podziel_z_resztą"? But it's a bit longer ❓ 'dziel_z_resztą' maybe?
+  enumerate: "wyliczaj" # ❓ "wylicz" sounds better ❓ agreed, 'wylicz' sounds more appropriate 
+  eval: "oceń" # ❓ I think it's quite similar to exec so I don't know what translation should be here ❓ 'oceń' or 'oszacuj' should be fine
+  exec: "wykonaj" # ✅✅
+  filter: "filtruj" # ✅✅
+  float: "zmiennoprzecinkowa" # liczba_zmiennoprzecinkowa?   Abbreviation: zmienno? [2ndOPINION] ✅ I think "zmiennoprzecinkowa" is fine ✅
+  format: "sformatuj" # ✅✅
+  frozenset: "niezmienny_zestaw" # niezmiennyzestaw? ✅ ❓ 'niezmienny_zbiór' sounds better to me. in polish, 'zestaw' would rather be used for e.g. a toy set 
+  getattr: "weź_atrybut" # weźatrybut? ❓ "pobierz_atrybut" would be better ✅ i don't mind 'weź' in this context
+  globals: "globalne" # wszystkie_globalne? ❓ "zmienne_globalne"? ❓ i like 'zmienne_globalne' or just 'globalne'
+  hasattr: "ma_atrybut" # maatrybut ✅✅
+  hash: "zakoduj" # ❓ "wartość_skrócona"? 🤔 really not sure about this one, might have to leave it as it is
+  help: "pomoc" # ✅✅
+  hex: "szesnastkowa" # ✅✅
+  id: "identyfikator" # Probably best to keep as "id". # ✅ both are fine here✅
+  input: "wkład" # wklad_użytkownika? ❓ "zmienna_wejściowa" might better? ❓ "zmienna_wejściowa" sounds most appropriate 
+  int: "liczba_całkowita" # ✅✅
+  isinstance: "jest_wystąpieniem" # jestwystąpieniem? # ✅✅
+  issubclass: "jest_podklasą" # jestpodklasą # ✅✅
+  iter: "iterator" # Probably best to keep as "iter". [2ndOPINION] 🤔 not sure if it's possible to translate ✅ 'iterator' sounds pretty straightforward to me
+  len: "ilość" # ❓ "długość" would be better ❓ i agree on 'długość'
+  list: "lista" # ✅✅
+  locals: "lokalne" # ❓ "zmienne_lokalne" would be better ✅ 'lokalne' sounds alright to me 
+  map: "zamapuj" # ❓ not sure how to translate it  🤔 i can only think of 'przypisz' [2ndOPINION]
+  max: "maksymalna" # ✅✅
+  memoryview: "widok_pamięciowy" # widokpamięciowy ✅✅
+  min: "minimalna" # ✅✅
+  next: "następny" # ✅✅
+  object: "objekt" # ❓ it should be "obiekt", aside from that it's fine ❓ 'obiekt'
+  oct: "ósemkowa" # ✅✅
+  open: "otwartym" # Was thinking "otwórz" but then we lose Python's speech-like flow. [2ndOPINION] ❓ i think "otwórz" would be better ❓ i agree on 'otwórz'
+  ord: "ord" # I can't think✅ of a sensible translation for this, probably best to keep as "ord"? [2ndOPINION] ❓ "numer_unicode"? ✅ i'd leave it as 'ord'
+  pow: "do_potęgi" # ✅
+  print: "drukuj" # ✅✅
+  property: "właściwość" # ✅✅
+  range: "zasięg" # ✅✅
+  repr: "przedrukuj" # przedruk? przedrukować? ❓ I think it's more like "reprezentacja"? 🤔
+  reversed: "odwróć" # odwrócić? odwrócona? ❓ "odwrócona" sounds better ❓ 'odwrócona'
+  round: "zaokrągl" # ✅✅
+  set: "ustaw" # ✅✅
+  setattr: "ustaw_atrybut" # ustawatrybut? # ✅✅
+  slice: "pokrój" # ❓ "potnij" sounds better ✅ either 'pokrój' or 'potnij' sound fine
+  sorted: "posortowana" # ✅✅
+  staticmethod: "metoda_statyczna" # metodastatyczna? ✅✅
+  str: "ciąg" # ✅✅
+  sum: "suma" # ✅✅
+  super: "rodzic" # ❓ actually I don't know what might be better for it, but "rodzic" doesn't sound quite right ❓ i'd probably leave it as 'super', but 'rodzic' is okay as well
+  tuple: "krotka" # ❓ "stała_lista"? "niezmienialna_tablica"? ✅ 
+  type: "typ" # ✅✅
+  vars: "zmienne" # ❓ maybe "atrybuty_zmiennej"? ✅ 'zmienne' is used commonly 
+  zip: "zip" # ✅✅
+  __import__: "__importuj__" # __importować__? ✅ "__importuj__" is fine✅
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: "przerwij"
+case: "przypadek"
+catch: "złap"
+class: "klasa"
+const: "stała"
+continue: "kontynuuj"
+debugger: "debugger"
+default: "domyślna"
+delete: "usuń"
+do: "rób"
+else: "inaczej"
+enum: "enumerator"
+export: "eksportuj"
+extends: "rozszerza"
+false: "fałsz"
+finally: "wreszcie"
+for: "dla"
+function: "funkcja"
+if: "jeśli"
+import: "importuj"
+in: "w"
+instanceof: "instancja"
+new: "nowa"
+null: "nic"
+return: "zwróc"
+super: "nadrzędna"
+switch: "zmieniaj"
+this: "to"
+throw: "rzuć"
+true: "prawda"
+try: "próbuj"
+typeof: "typz"
+var: "zmienna"
+void: "nic"
+while: "dopóki"
+with: "z"
+as: "jako"
+implements: "implementuje"
+interface: "interfejs"
+let: "niech"
+package: "pakiet"
+private: "prywatna"
+protected: "chroniona"
+public: "publiczna"
+static: "statyczna"
+yield: "zwracaj"
+any: "dowolna"
+boolean: "boolowska"
+constructor: "konstruktor"
+declare: "deklaruj"
+get: "weź"
+module: "moduł"
+require: "wymagaj"
+number: "liczba"
+set: "zbiór"
+string: "wyraz"
+symbol: "symbol"
+type: "typ"
+from: "z"
+of: "od"
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/pt.yml
+++ b/locale/pt.yml
@@ -1,0 +1,2238 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "pt"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "NOTA"
+  INFO: "INFORMAÇÃO"
+  IDEA: "IDEIA"
+  DEBUG: ""
+  REMOVE: "REMOVER"
+  OPTIMIZE: "OTIMIZAR"
+  REVIEW: "REVISAR"
+  HACK: ""
+  UNDONE: "INCOMPLETO"
+  TODO: "PARA FAZER"
+  REFACTOR: "REFAZER"
+  DEPRECATED: "DESCONTINUADO"
+  TASK: "TAREFA"
+  CHGME: ""
+  NOTREACHED: "NÃO ATINGIDO"
+  WTF: ""
+  BUG: "INSETO"
+  ERROR: "ERRO"
+  OMG: "OH MEU DEUS"
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: "AVISO"
+  WARN: ""
+  BROKEN: "QUEBRADO"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: "abstrato"
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: "dado"
+  do: "fazer"
+  eta-equality: ""
+  field: "campo"
+  forall: ""
+  hiding: "esconder"
+  import: "importar"
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: "módulo"
+  mutual: "mútuo"
+  no-eta-equality: ""
+  open: "abrir"
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: "primitivo"
+  private: "privado"
+  public: "público"
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: "gravar"
+  renaming: "renomear"
+  rewrite: "reescrever"
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "sintaxe"
+  tactic: "tática"
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: "usando"
+  where: "aonde"
+  with: "com"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "fazer" # (part of do-while statement)
+while: "enquanto"
+for: "para"
+if: "se" # (part of if-else statement)
+else: "se não" # (part of if-else statement)
+switch: "trocar"
+break: "quebrar" # (part of the switch statement or for/while statements)
+case: "caso" # (part of the switch statement)
+continue: "continue" # (part of for/while statements)
+default: "padrão" # (part of switch statement)
+function: "função"
+procedure: "procedimento"
+return: "retorne"
+local: "local"
+global: "global"
+static: "estático"
+typeof: "tipo de"
+NOT: "não"
+AND: "e"
+OR: "ou"
+Null: "Nulo"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "caso"
+do: "faça"
+done: "feito"
+elif: "se não, se"
+else: "se não"
+esac: "fim caso"
+fi: "fim se"
+for: "por"
+function: "função"
+if: "se"
+in: "dentro"
+select: "selecionar"
+then: "então"
+time: "tempo"
+until: "até que"
+while: "enquanto"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "auto"
+double: "duplo"
+int: "int"
+struct: "struct"
+break: "quebrar"
+else: "se não"
+long: "longo"
+switch: "trocar"
+case: "caso"
+enum: "enum"
+register: "registrar"
+typedef: ""
+char: "char"
+extern: "externo"
+return: "retornar"
+union: "união"
+const: "const"
+float: "flutuante"
+short: "curto"
+unsigned: "sem sinal"
+continue: "continue"
+for: "por"
+signed: "com sinal"
+void: "vazio"
+default: "padrão"
+goto: "va para"
+sizeof: "tamnho de"
+volatile: "volátil"
+do: "faça"
+if: "se"
+static: "estático"
+while: "enquanto"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: "#defina"
+#defined: "#definido"
+#elif: ""
+#else: ""
+#endif: ""
+#error: "#erro"
+#if: "#se"
+#ifdef: ""
+#ifndef: ""
+#include: "#inclua"
+#line: "#linha"
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: "#e"
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: "auto"
+bitand: ""
+bitor: ""
+bool: "boleano"
+break: "quebre"
+case: "caso"
+catch: "pegar"
+char: "carac"
+char16_t: ""
+char32_t: ""
+class: "classe"
+compl: ""
+concept: "conceito"
+const: "const"
+constexpr: ""
+const_cast: ""
+continue: "continuar"
+decltype: ""
+default: "padrão"
+delete: "deletar"
+do: "faça"
+double: "duplo"
+dynamic_cast: ""
+else: "se não"
+enum: "enum"
+explicit: "explicito"
+export: "exportar"
+extern: "externo"
+false: "falso"
+final: "final"
+float: "Flutuante"
+for: "para"
+friend: "amigo"
+goto: "vapara"
+if: "se"
+inline: "na linha"
+int: "int"
+import: "importe"
+long: "longo"
+module: "modulo"
+mutable: "mutavel"
+namespace: ""
+new: "novo"
+noexcept: ""
+not: "não"
+not_eq: ""
+nullptr: "ponteiro nulo"
+operator: "operador"
+or: "ou"
+or_eq: ""
+override: "sobrescrita"
+private: "privado"
+protected: "protegido"
+public: "público"
+register: "registrar"
+reinterpret_cast: ""
+requires: "necessário"
+return: "retorne"
+short: "curto"
+signed: "com sinal"
+sizeof: "tamanho de"
+static: "estático"
+static_assert: ""
+static_cast: ""
+struct: "estrutura"
+switch: "trocar"
+synchronized: "sincronizado"
+template: "modelo"
+this: "isso"
+thread_local: ""
+throw: "lançar"
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: "verdadeiro"
+try: "tente"
+typedef: ""
+typeid: ""
+typename: ""
+union: "união"
+unsigned: "sem sinal"
+using: "usando"
+virtual: "virtual"
+void: "vazio"
+volatile: "volátil"
+wchar_t: ""
+while: "enquanto"
+xor: "xor"
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: "quebra"
+default: "padrão"
+func: "função"
+interface: "interface"
+select: "selecionar"
+case: "caso"
+defer: "adiar"
+go: "go"
+map: "mapa"
+struct: "estrutura"
+chan: "canal"
+else: "se não"
+goto: "ir para"
+package: "pacote"
+switch: "troca"
+const: "constante"
+fallthrough: "cair em"
+if: "se"
+range: "alcance"
+type: "tipo"
+continue: "continue"
+for: "para"
+import: "importar"
+return: "retornar"
+var: "variável"
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: "abstrato"
+continue: "continuar"
+for: "para"
+new: "novo"
+switch: "comutador"
+assert: "afirmar"
+default: "padrão"
+goto: "ir para"
+package: "pacote"
+synchronized: "sincronizado"
+boolean: "booleano"
+do: "faça"
+if: "se"
+private: "privado"
+this: "este"
+break: "quebra"
+double: ""
+implements: "implementa"
+protected: "protegido"
+throw: "lançar"
+byte: "byte"
+else: "se não"
+import: "importar"
+public: "público"
+throws: "lança"
+case: "caso"
+enum: ""
+instanceof: "instância de"
+return: "retornar"
+transient: ""
+catch: "pegar"
+extends: "extende"
+int: "inteiro"
+short: ""
+try: "tentar"
+char: "caractere"
+final: "final"
+interface: "interface"
+static: "estático"
+void: "vazio"
+class: "classe"
+finally: "finalmente"
+long: ""
+strictfp: ""
+volatile: "volátil"
+const: "constante"
+float: "flutuante"
+native: "nativo"
+super: "super"
+while: "enquanto"
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: "argumentos"
+await: "espera"
+break: "quebra"
+case: "caso"
+catch: "pegue"
+class: "classe"
+const: "constante"
+continue: "continue"
+debugger: "depurador"
+default: "padrão"
+delete: "apague"
+do: "faça"
+else: "se não"
+enum: "enumere"
+eval: "valorize"
+export: "exporte"
+extends: "extende"
+false: "falso"
+finally: "finalmente"
+for: "para"
+from: "de"
+function: "função"
+if: "se"
+implements: "implementa"
+import: "importe"
+in: "em"
+instanceof: "instância de"
+interface: "interface"
+let: "deixe"
+new: "novo"
+null: "nulo"
+package: "pacote"
+private: "privado"
+protected: "protegido"
+public: "público"
+return: "retorne"
+static: "estático"
+super: "super"
+switch: "troque"
+this: "este"
+throw: "lance"
+true: "verdadeiro"
+try: "tente"
+typeof: "tipo de"
+var: "variável"
+void: "vazio"
+while: "enquanto"
+with: "com"
+yield: "produza"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: "__nomedodiretório"
+__filename: "__nomedoarquivo"
+exports: "exporta"
+module: "módulo"
+require: "requer" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Falso"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  None: "Nada"
+    #❓
+    #Fayhen-❓ - Can be translated as-is or changed to 'nenhum'
+    #geraldobraz-❓
+    #fernandakawasaki-❓
+    #annemacena-❓ - Agree with Fayhen (leave it as it is or change to "Nenhum").
+  True: "Verdadeiro"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  and: "e"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  as: "como"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  assert: "assegure"
+    #❓
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('assegurar')
+    #geraldobraz-❓
+    #fernandakawasaki-❓ - Verb used does not seem right, maybe use 'certificar'
+    #annemacena-❓ This verb is kinda odd but, as Fayhen, correct. Maybe 'Certificar', as Fernanda said, it's more common. Or even better: 'garantir' (ensure).
+  async: "assíncrono"
+    #Maybe remove the special character
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  await: "aguarde"
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('aguardar')
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  break: "quebre"
+    #❓
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('quebrar')
+    #geraldobraz-❓
+    #fernandakawasaki-❓ - Verb is too literal
+    #annemacena-❓ - I can suggest the verb "parar" (stop).
+  class: "classe"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  continue: "continue"
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('continuar')
+    #geraldobraz-❓
+    #fernandakawasaki-❓
+    #annemacena-✅ - I can't imagine another word for it, at most switch to infinitive.
+  def: "def"
+    #define -> 'definir' (def still)
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Ok... MAYBE more informative change to definir or "declarar" (declare). Not a big deal.
+  del: "del"
+    #delete -> 'deletar' (or 'apagar', 'remover')
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Same as in "def", MAYBE more informative change to "deletar" (delete).
+  elif: "sense"
+    #if -> 'se', else -> 'senão'... elif -> 'sen(ão)' + 'se' = 'sense'
+    #Fayhen-❓ - An alternative could be 'ouse' ('ou' + 'se')
+    #geraldobraz-❓
+    #fernandakawasaki-❓
+    #annemacena-❓ - This is a tricky one. "senãose" looks better than "sense". senãose = senão (else) + se (if).
+  else: "senão"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  except: "exceto"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  finally: "finalmente"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  for: "para"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  from: "de"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  global:  "global"
+    #The same, no variation
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  if: "se"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  import: "importe"
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('importar')
+    #geraldobraz-❓
+    #fernandakawasaki-❓
+    #annemacena-✅
+  in: "em"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  is: "é"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  lambda: "lambda"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  nonlocal: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'nãolocal' (non -> 'não' + local -> 'local')
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "nãolocal" looks good.
+  not: "não"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  or: "ou"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  pass: "passe"
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('passar')
+    #geraldobraz-❓
+    #fernandakawasaki-❓
+    #annemacena-✅ - I can't imagine another word for it, at most switch to infinitive.
+  raise: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'levatar', which goes well with the keyword context (raise Exception -> 'levatar Exceção')
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - Fayhen's suggestion looks good, but there's a writing error, the correct word it's "levantar". My suggestion is "invocar" (invoke).
+  return: "retorne"
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('retornar')
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  try: "tente"
+    #Fayhen-❓ - Verb is correct but may be better kept on its infinitive form ('tentar')
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  while: "enquanto"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  with: "com"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  yield: ""
+    #Fayhen-🤔 - No translation given at time of review. Also, there isn't a good match in pt for this word. A suggestion is 'produzir' (pt for 'produce'/'yield')
+    #geraldobraz-🤔
+    #fernandakawasaki-🤔
+    #annemacena-🤔 - MAYBE because yield it's commonly relate to generator functions, I can suggest the word "gerar" (generate). The literal translation is "produzir".
+
+# << Built-In Functions >>
+
+  abs: "abs"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - MAYBE more informative change to "absoluto" (absolute).
+  all: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'todos', which references all elements inside an iterable
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - Tricky one. My suggestion is "verdadeiro" (true). "todos" it's the literal translation.
+  any: "qualquer"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  ascii: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is keeping it the same in both languages
+    #geraldobraz-🤔
+    #fernandakawasaki-🤔
+    #annemacena-🤔 - Keep as it is.
+  bin: "bin"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  bool: "bool"
+    #🤔
+    #Fayhen-❓ - Can be translated to 'boleano' (pt for 'boolean') or shortened to 'bol'.
+    #geraldobraz-🤔
+    #fernandakawasaki-🤔
+    #annemacena-❓ - Agree with Fayhen, "booleano". Informative.
+  breakpoint: ""
+    #Fayhen-❓ - No translation given at time of review. Because this function is called for debigging purposes, it can be translated as 'pontodeparada' (point -> 'ponto' + 'de' (adposition) + break -> 'parada'), or 'pontodeinterrupção' (interruption -> 'interrupção', because the method interrupts code execution). Perhaps, it can also be left as-is.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - This is the kind of word that we just keep as it is. But "pontodeparada" looks good.
+  bytearray: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'matrizdebytes' (array -> 'matriz' + 'de' (adposition) + 'bytes' (unchanged in translation)), or 'mtzbytes'.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "matrizdebytes" looks good. Or "vetordebytes". matriz = matrix, vetor = vector.
+  bytes: ""
+    #Fayhen-❓ - No translation given at time of review. 'bytes' is unchanged upon translation and can be left as-is.
+    #fernandakawasaki-🤔
+    #annemacena-🤔 - Keep as it is.
+  callable: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'chamável', for this method indicates whether an object can be called ('chamado').
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓- "chamável" looks good.
+  chr: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'char', for 'caractere' (character).
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "caractere" (character) looks good. Informative.
+  classmethod: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'métododeclasse' (method -> 'método' + 'de' (adposition) + class -> 'classe'), or 'metclass'.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "métododeclasse" looks good.
+  compile: "compilar"
+    #Assuming it's a verb
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  complex: "complexo"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  delattr: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'delatr' (delete -> 'deletar' -> 'del' + attribute -> 'atributo' -> 'atr')
+    #geraldobraz-🤔
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - My suggestion is the full form of Fayhen's suggestion: "deletaratributo". deletar (delete) + atributo (attribute) = deletaratributo.
+  dict: "dic"
+    #Dictionaty -> 'Dicionário'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or the full form "dicionário", more informative.
+  dir: ""
+    #Fayhen-🤔 - No translation given at time of review.
+    #geraldobraz-❓ - I think dir may be translate to "diretório" if you follow the example above. So dir = "dir"
+    #fernandakawasaki-🤔
+    #annemacena-🤔 - Tricky one. Keep as it is.
+  divmod: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'divint'. This function divides two integers, preserving the remainder and returning it together with the quotient. So, 'divisão de inteiros' (integer division) -> 'divint'.
+    #geraldobraz-🤔
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - My suggestion is the full form of Fayhen's suggestion: "dividirinteiros". dividir (divide) + inteiros (integers) = dividirinteiros.
+  enumerate: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'enumerar'.
+    #geraldobraz-❓
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "enumerar" looks good.
+  eval: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'aval' (evaluate -> 'avaliar').
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - Tricky one. I suggest keep as it is, "avaliar" looks weird, too literal.
+  exec: ""
+    #Fayhen-❓ - No translation given at time of review. Can be left as-is (execute/execution -> 'executar'/'execução').
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "executar" looks good.
+  filter: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'filtrar'.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "filtrar" looks good.
+  float: "" 
+    #🤔
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'real' (real numbers -> 'números reais' on plural and 'real' on singular).
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "real" looks good.
+  format: "formato"
+    #❓ #Assuming it's a noun (not verb etc)
+    #Fayhen-❓ - It is better left as a verb ('formatar'). Python uses `format` to convert values to a given representation and there is also a string formatting method with same name.
+    #fernandakawasaki-❓
+    #annemacena-❓ - "formatar" looks good.
+  frozenset: ""
+    #Fayhen-❓ - No translation given at time of review. No good match for it in pt, but a suggestion is 'conjuntoimutável' (set -> 'conjunto' + immutable -> 'imutável', referring to `frozenset` objects' properties), or an abbreviation of that ('cjtimut').
+    #geraldobraz-🤔
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "conjuntoimutável" looks good.
+  getattr: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'pegaratr' (get -> 'pegar' + attribute -> 'atributo' -> 'atr').
+    #geraldobraz-🤔
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - My suggestion is the full form of Fayhen's suggestion: "pegaratributo". pegar (get) + atributo (attribute) = pegaratributo.
+  globals: "globais"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  hasattr: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'possuiatr' (has -> 'possui' + attribute -> 'atributo' -> 'atr').
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - My suggestion is the full form of Fayhen's suggestion: "possuiatributo". possui (get) + atributo (attribute) = possuiatributo.
+  hash: "hash"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  help: "ajuda"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  hex: "hex"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  id: "id"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  input: "entrada"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  int: "int"
+    #Integer -> 'inteiro'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "inteiro". Informative.
+  isinstance: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'éinstância' (is -> 'é' + instance -> 'instância').
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "éinstância" looks good.
+  issubclass: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'ésubclasse' (is -> 'é' + instance -> 'subclasse').
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "ésubclasse" looks good.
+  iter: "iter"
+    #❓ #iterate, iterable, iterative -> 'iterar, iterável, iterativo' (pretty much the same)
+    #Fayhen-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "iterável". Informative.
+  len: "tam"
+    #lenght -> 'tamanho' or 'comprimento'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "tamanho". Informative.
+  list: "lista"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  locals: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'locais'.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "locais" looks good.
+  map: "map"
+    #map (verb) -> 'mapear' (map still)
+    #Fayhen-✅
+    #geraldobraz-❓ - mapear
+    #fernandakawasaki-❓ - Too literal
+    #annemacena-✅ - Or "mapear". Informative.
+  max: "max"
+    #Maximum -> 'Máximo' (max still)
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "máximo". Informative.
+  memoryview: ""
+    #Fayhen-🤔 - No translation given at time of review.
+    #fernandakawasaki-🤔 - Translation currently not available
+    #annemacena-🤔 - Keep as it is.
+  min: "min"
+    #❓
+    #minimun -> 'mínimo' (min still, except for the accent)
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "mínimo". Informative.
+  next: "próximo"
+    #next -> próximo
+    #Fayhen-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  object: "objeto"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  oct: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'octal' (same in pt/en), or keeping it as 'oct'.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "octal" looks good.
+  open: "abrir"
+    #Assuming it's a verb
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  ord: ""
+    #Fayhen-❓ - No translation given at time of review. What this function does is take a string containing any character and return its Unicode representation. Therefore, perhaps it could be translated as 'unicode', or kept as-is.
+    #fernandakawasaki-🤔
+    #annemacena-❓ - "unicode" looks good.
+  pow: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'pot' (power -> 'potência' -> pot).
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "potência" looks good.
+  print: ""
+    #🤔 #print is 'imprimir', but in practice, we use 'printar'. So I believe it's better to stay with print
+    #Fayhen-🤔 - As stated above, it could be left as 'print' because of our portuguese slang for ('printar').
+    #fernandakawasaki-🤔
+    #annemacena-🤔 - Same as said above, it's common to use "printar" slang. But maybe it's more informative the word "imprimir".
+  property: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'propriedade'.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "propriedade" looks good.
+  range: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is 'alcance'.
+    #fernandakawasaki-❓ - Translation currently not available. Maybe use 'percorrer'
+    #annemacena-❓ - "percorrer" looks good.
+  repr: "repr" #❓
+    #Representation -> 'Representação'
+    #Fayhen-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "representação". Informative.
+  reversed: "revertido"
+    #more common is 'invertido', but to maintain a certain consistance with the language, i chose 'revertido', which also exists
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-❓ - "invertido" looks right and more common, "revertido" it's weird.
+  round: "arredondar"
+    #round as adjective is 'redondo', but as a verb is 'arredondar'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  set: "definir"
+    #set -> 'definir'
+    #Fayhen-❓ - `set` in this function actually refers to an iterable group of elements, which should be translated as 'conjunto' or abbreviation of that (e.g. 'cjt').
+    #fernandakawasaki-❓
+    #annemacena-❓ - "conjunto" looks good.
+  setattr: "definiratr"
+    #set -> 'definir', attribute -> 'atributo'
+    #Fayhen-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or the full form "definiratributo".
+  slice: "fatiar"
+    #❓ #slice as a noun is 'fatia', but as a verb is 'fatiar'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-❓ - Maybe too literal? Another option is 'cortar'
+    #annemacena-❓ - Too literal. "cortar" it's ok but maybe "dividir" (divide) it's more common.
+  sorted: "ordenado"
+    #sort -> 'ordenar'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  staticmethod: "metodoestatico"
+    #static -> 'estático', method -> 'método'
+    #Fayhen-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  str: "str"
+    #🤔 #The translation for string is 'linha', but it's not really used with this meaning
+    #Fayhen-🤔
+    #geraldobraz-🤔
+    #fernandakawasaki-🤔
+    #annemacena-🤔 - Keep as it is OR full version as "string".
+  sum: "soma"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  super: "super"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  tuple: "tupla"
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  type: "tipo"
+    #Type (meaning kind, group; not keyboard typing) -> 'Tipo'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅
+  vars: "vars"
+    #Variables -> 'Variáveis'
+    #Fayhen-✅
+    #geraldobraz-✅
+    #fernandakawasaki-✅
+    #annemacena-✅ - Or "variaveis". Informative.
+  zip: "zip"
+    #🤔
+    #Fayhen-❓ - Given the aggregation of iterators that this function does, maybe it could be translated as 'agregar' (aggregate) or abbreviation of that ('agg'). Or perhaps it could be left as-is.
+    #geraldobraz-🤔
+    #fernandakawasaki-🤔
+    #annemacena-❓ - "agregar" looks ok but "juntar" it's more common.
+  __import__: ""
+    #Fayhen-❓ - No translation given at time of review. A suggestion is '__importar__', preserving the double underscores since this is a Python dunder method.
+    #fernandakawasaki-❓ - Translation currently not available
+    #annemacena-❓ - "__importar__" looks good.
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: "apelido"
+and: "e"
+begin: "começo"
+break: "quebre"
+case: "caso"
+class: "classe"
+def: "definição"
+defined?: "definido?"
+do: "faça"
+else: "se não"
+elsif: "se não, se"
+end: "fim"
+ensure: "garantir"
+false: "false"
+for: "para"
+if: "se"
+in: "em"
+module: "módulo"
+next: "próximo"
+nil: "nulo"
+not: "não"
+or: "ou"
+redo: "refaça"
+rescue: "resgate"
+retry: "re-tentar"
+return: "retorne"
+self: "próprio"
+super: "super"
+then: "então"
+true: "verdadeiro"
+undef: "não definido"
+unless: "a menos que"
+until: "até"
+when: "quando"
+while: "enquanto"
+yield: "dar"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/ro.yml
+++ b/locale/ro.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "ro"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: ""
+  None: ""
+  True: ""
+  and: ""
+  as: ""
+  assert: ""
+  async: ""
+  await: ""
+  break: ""
+  class: ""
+  continue: ""
+  def: ""
+  del: ""
+  elif: ""
+  else: ""
+  except: ""
+  finally: ""
+  for: ""
+  from: ""
+  global:  ""
+  if: ""
+  import: ""
+  in: ""
+  is: ""
+  lambda: ""
+  nonlocal: ""
+  not: ""
+  or: ""
+  pass: ""
+  raise: ""
+  return: ""
+  try: ""
+  while: ""
+  with: ""
+  yield: ""
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/ru.yml
+++ b/locale/ru.yml
@@ -1,0 +1,1821 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "ru"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "ложь" # ✅
+  None: "ничто" # ✅
+  True: "истина" # ✅
+  and: "и" # ✅
+  as: "как" # ✅
+  assert: "утверждать" # ✅
+  async: "асинхронной" # 🤔 асинхронно
+  await: "ожидать" # ✅
+  break: "прерывать" # 🤔 прервать
+  class: "класс" # ✅
+  continue: "продалжать" # 🤔 продолжать
+  def: "определить" # ✅
+  del: "удалить" # ✅
+  elif: "иначе–если" # ✅
+  else: "иначе" # ✅
+  except: "кроме" # ✅
+  finally: "наконец" # 🤔 вне зависимости от наличия исключений выполнить
+  for: "для" # ✅
+  from: "из" # ✅
+  global: "глобальный" # ✅
+  if: "если" # ✅
+  import: "импортировать" # ✅
+  in: "в" # ✅
+  is: "является"  # ✅
+  lambda: "лямбда" # ✅
+  nonlocal: "нелокальный" # ✅
+  not: "не" # ✅
+  or: "или" # ✅
+  pass: "пропускать" # 🤔 пропустить
+  raise: "поднимать" # 🤔 поднять
+  return: "вернуть" # ✅
+  try: "попробовать" # ✅
+  while: "пока" # ✅
+  with: "с" # ✅
+  yield: "выдать" # ✅
+
+# << Built-In Functions >>
+
+  abs: "абсолютный" / "абс" # ✅
+  all: "все" # ✅
+  any: "какой-нибудь" # 🤔 любой
+  ascii: "ASCII-код" # ✅
+  bin: "бинарный" # ✅
+  bool: "булев" # ✅
+  breakpoint: "точка-останова" # ✅
+  bytearray: "байтовый-массив" # ✅
+  bytes: "байты" # ✅
+  callable: "вызываемый" # ✅
+  chr: "символ" # ✅
+  classmethod: "метод-класса" # ✅
+  compile: "компилировать" # ✅
+  complex: "сложный" # ✅
+  delattr: "удалить-атрибут" # ✅
+  dict: "словарь" # ✅
+  dir: "директория" # ✅
+  divmod: "деление-нацело" # ✅
+  enumerate: "перечислить" # ✅
+  eval: "вычислить" # ✅
+  exec: "исполнять" # 🤔 исполнить
+  filter: "фильтровать" # ✅
+  float: "плавающая-точка" # ✅
+  format: "формат" # ✅
+  frozenset: "замороженный-набор" # ✅
+  getattr: "добыть-атрибут" # ✅
+  globals: "глобальные" # ✅
+  hasattr: "имеет-атрибут" # ✅
+  hash: "хеш" # ✅
+  help: "помогать" # ✅
+  hex: "шестнадцатеричный" # ✅
+  id: "идентификатор" # ✅
+  input: "ввод" # ✅
+  int: "целое-число" # ✅
+  isinstance: "является-экземпляром" # ✅
+  issubclass: "является-подклассом" # ✅
+  iter: "итераратор" # ✅
+  len: "длина" # ✅
+  list: "список" # ✅
+  locals: "локальные" # ✅
+  map: "таблица" # ✅
+  max: "максимум" # ✅
+  memoryview: "обзор-памяти" # ✅
+  min: "минимум" # ✅
+  next: "следующий" # ✅
+  object: "объект" # ✅
+  oct: "октальный" # ✅
+  open: "открывать" # 🤔 открыть
+  ord: "порядковый" # ✅
+  pow: "степень" # ✅
+  print: "печатать" # ✅
+  property: "свойство" # ✅
+  range: "дипазон" # ✅
+  repr: "представление" # ✅
+  reversed: "обратный" # ✅
+  round: "округлить" # ✅
+  set: "набор" # ✅
+  setattr: "определить-атрибут" # ✅
+  slice: "срез" # ✅
+  sorted: "отсортированный" # ✅
+  staticmethod: "статичный-метод" # ✅
+  str: "строка" # ✅
+  sum: "сумма" # ✅
+  super: "супер" # ✅
+  tuple: "кортеж" # ✅
+  type: "тип" # ✅
+  vars: "переменные" # ✅
+  zip: "итератор-по-кортежам" # ✅
+  __import__: "__импорт__" # ✅
+
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/te.yml
+++ b/locale/te.yml
@@ -1,0 +1,2542 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "te"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "తప్పు"
+    # ✅ @nagendrady
+    # ❓ @manojkrishnak May be a better translation is required. Although the translation is correct, when it comes to programming it might not be correct. అసత్యం can be considered.
+    # ✅ @Ln11211 seems alright
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  None: "ఏదీ లేదు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ❓ @KarthikMothiki none can be used on situation based in telugu. It can also be  ఏమీ కాదు
+    # 👀 @sujithkumardola
+    # ❓ @sneha-thyagarajan i guess ఏమీ కాదు would be a perfect translation
+    # ✅ @sh1fu-X
+  True: "నిజం"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  and: "మరియు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  as: "గా"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  assert: "నొక్కి చెప్పండి"
+    # ✅ @nagendrady
+    # ❓ @manojkrishnak May be a better translation is required. కచ్చితంగా can be considered in programming perscpective.
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ❓ @sneha-thyagarajan if we look from the programming perspective ధృవీకరించండి might be a better fit, as it is used to confirm a condition
+    # ✅ @sh1fu-X
+  async: ""
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 🤔 @Ln11211 A translation is difficult for this, but "అసమకాలిక" is the translation for "Asynchronous" and can be used
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # 🤔 @sneha-thyagarajan 
+    # 🤔 @sh1fu-X
+  await: "వేచిఉండు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ❓ @KarthikMothiki await can also be written as నిరీక్షించు
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  break: "బయటకి వచ్చుట"
+    # 👀 @nagendrady
+    # ❓ @manojkrishnak "బయటకి వచ్చుట" May be considered as better translation in programming perscpective.
+    # ✅ @Ln11211
+    # ❓ @KarthikMothiki another word for break can be written as విరమించు
+    # 👀 @sujithkumardola
+    # ❓ @sneha-thyagarajan విరమించు sounds more close to the keyword
+    # ✅ @sh1fu-X
+  class: "తరగతి"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ❓ @sh1fu-X In general language, "తరగతి" can mean "class," but in the context of programming, "వర్గం" is a more suitable.
+  continue: "కొనసాగించు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  def: "వివరణ"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ❓ @KarthikMothiki def key will be better with నిర్వచన
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  del: "తొలగించు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  elif: "లేకుంటే"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  else: "లేకపోతే"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  except: "ఇది తప్ప"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  finally: "చివరకు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  for: "దానికోసం"
+    # 👀 @nagendrady
+    # ❓ @manojkrishnak "దానికోసం" May be considered as better translation in programming perscpective.
+    # ❓ @Ln11211 Maybe "కోఱకు" seems apt.
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  from: "నుండి"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  global: "ప్రపంచ"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  if: "అయితే"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  import: "దిగుమతి"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  in: "లో"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ❓ @KarthikMothiki లో or లోపల is fine they both gives the same sense
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  is: "ఉంది"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  lambda: "లాంబ్డా"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak This is true translation of word; Although we cannot translate this word
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  nonlocal: ""
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 🤔 @Ln11211 A translation is difficult for this, but "నాన్ లోకల్" seems ok.
+    # 🤔 @KarthikMothiki స్థానికేతర is the exact word for non-local but many people would prefer hard-translation itself.
+    # 👀 @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # 🤔 @sh1fu-X
+  not: "లేదు"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  or: "లేదా"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki 
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  pass: "పాస్"
+    # ✅ @nagendrady
+    # ❓ @manojkrishnak Here true translation is written, there is an better alternative, that's అందించుట.
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  raise: "పెంచండి"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ❓ @KarthikMothiki when it comes to hard translation of the context ఎత్తుట will work good
+    # 👀 @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  return: "తిరిగి వచ్చు"
+    # ✅ @nagendrady
+    # ❓ @manojkrishnak జవాబు ఇచ్చు, బయటకి వచ్చుట may be considered as better translations depending upon the usage(return some value or come out of the loop/if condition).
+    # ❓ @Ln11211 "తిరిగిఇచ్చుట" seems apt for the "return" keyword
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ❓ @sneha-thyagarajan తిరిగిఇచ్చుట is a good replacement as @Ln11211 said
+    # ✅ @sh1fu-X
+  try: "ప్రయత్నించండి"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ❓ @Ln11211 "ప్రత్నించు" is better translation for "try"
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  while: "అయితే"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  with: "తో"
+    # ✅ @nagendrady
+    # ✅ @manojkrishnak
+    # ✅ @Ln11211
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  yield: "లభించు"
+    # ✅ @nagendrady
+    # ❓ @manojkrishnak May be a better translation is required.
+    # ❓ @Ln11211 Would recommend using "లబించుట", "లభించు" is also fine.
+    # ✅ @KarthikMothiki
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+
+# << Built-In Functions >>
+
+  # @KarthikMothiki: Some of the keywords are hard-translated!
+  abs: "సంపూర్ణ సంఖ్య"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "సంపూర్ణ సంఖ్య"
+    # ✅ @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  all: "అన్ని"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "అన్ని"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  any: "ఏదైనా"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఏదైనా"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  ascii: "ఆశ్కి"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "ఆశ్కి" there is no word for ascii in telugu
+    # ✅ @sujithkumardola "ఆశ్కి" looks fine
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  bin: "బైనరీ"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "బైనరీ"
+    # 👀 @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  bool: "బూలియన్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "బూలియన్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  breakpoint: "బ్రేక్ పాయింట్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "బ్రేక్ పాయింట్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  bytearray: "బైట్ అమరిక"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211  
+    # ✅ @KarthikMothiki "బైట్ అమరిక"
+    # ✅ @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  bytes: "బైట్లు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "బైట్లు"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  callable: "పిలవదగినది"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "పిలవదగినది"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  chr: ""
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 👀 @KarthikMothiki
+    # ❓ @sujithkumardola maybe "అక్షరము" makes a better translation
+    # 🤔 @sneha-thyagarajan
+    # ❓ @sh1fu-X "అక్షరము" can be used.
+  classmethod: "తరగతి కర్మము"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 👀 @KarthikMothiki "తరగతి కర్మము"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  compile: "గ్రంథస్తం చేయు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "గ్రంథస్తం చేయు"
+    # ✅ @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  complex: "కాంప్లెక్స్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "కాంప్లెక్స్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  delattr: "ఆస్ట్రిబ్యూటె తొలిగింపు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఆస్ట్రిబ్యూటె తొలిగింపు"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  dict: "డిక్షనరీ"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "డిక్షనరీ"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  dir: "డైరెక్టరీ"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "డైరెక్టరీ"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  divmod: "విభజన మాడ్యూల్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "విభజన మాడ్యూల్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  enumerate: "లెక్కించు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "లెక్కించు"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  eval: "మూల్యాంకన"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "మూల్యాంకన"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  exec: "అమలు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "అమలు"
+    # ✅ @sujithkumardola
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  filter: "వడపోత"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "వడపోత"
+    # 👀 @sujithkumardola needs a better translation
+    # 🤔 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  float: "దశాంశ"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki  "దశాంశ"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  format: "ఫార్మాట్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఫార్మాట్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  frozenset: "ఫ్రోజెన్ సెట్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "ఫ్రోజెన్ సెట్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  getattr: "ఆస్ట్రిబ్యూట్ పొందుట"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఆస్ట్రిబ్యూట్ పొందుట"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  globals: "గ్లోబల్స్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "గ్లోబల్స్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  hasattr: "ఆస్ట్రిబ్యూటె ఉంది"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఆస్ట్రిబ్యూటె ఉంది"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  hash: "హాష్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "హాష్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  help: "తోడ్పాటు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "తోడ్పాటు"
+    # ❓ @sujithkumardola "సహాయం" is a better translation
+    # ✅ @sneha-thyagarajan
+    # 🤔 @sh1fu-X "సహాయం" might be a little bit better
+  hex: "హెక్స్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "హెక్స్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  id: "గుర్తింపు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "గుర్తింపు"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  input: "ఇన్పుట్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "ఇన్పుట్"
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  int: "పూర్ణ సంఖ్య"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "పూర్ణ సంఖ్య"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  isinstance: "ఇన్స్టన్స్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "ఇన్స్టన్స్"
+    # ❓ @sujithkumardola "ఇస్ఇన్స్టన్" is a better translation
+    # ✅ @sneha-thyagarajan
+    # ❓ @sh1fu-X "ఇస్ఇన్స్టన్స్" is a better one.
+  issubclass: "ఐస్ సబ్ క్లాస్ "
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఐస్ సబ్ క్లాస్ "
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  iter: "మరల"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "మరల"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  len: "పొడవు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "పొడవు"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  list: "పట్టిక"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "పట్టిక"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  locals: "స్థానిక"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "స్థానిక"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  map: "మ్యాప్ "
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "మ్యాప్ "
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  max: "గరిష్ట"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "గరిష్ట"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  memoryview: "మెమరీ వ్యూ "
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "మెమరీ వ్యూ "
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  min: "కనిష్ట"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "కనిష్ట"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  next: "తరువాత"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "తరువాత"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  object: "వస్తువు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "వస్తువు"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  oct: "ఆక్టల్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ఆక్టల్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  open: "తెరుచుట"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "తెరుచుట"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  ord: "ఒర్డ్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "ఒర్డ్"
+    # 👀 @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  pow: "ఘాతాంకం"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "ఘాతాంకం"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  print: "ముద్రించుట"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ముద్రించుట"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  property: "ప్రాపర్టీ"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "ప్రాపర్టీ"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  range: "పరిధి"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "పరిధి"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  repr: "రిప్రెసెంట్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "రిప్రెసెంట్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  reversed: "తిరగపడిన"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki  "తిరగపడిన"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  round: "చుట్టు"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # 🤔 @KarthikMothiki "చుట్టు"
+    # ❓ @sujithkumardola
+    # 👀 @sneha-thyagarajan 
+    # ✅ @sh1fu-X
+  set: "సెట్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "సెట్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  setattr: "సెట్ ఆస్ట్రిబ్యూటె"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki  "సెట్ ఆస్ట్రిబ్యూటె"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  slice: "భాగము"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "భాగము"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  sorted: "క్రమబద్ధీకరించబడింది"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "క్రమబద్ధీకరించబడింది"
+    # ✅ @sujithkumardola
+    # ❓ @sneha-thyagarajan వర్గీకరించు might be apt choice
+    # ✅ @sh1fu-X
+  staticmethod: "స్టాటిక్ పద్ధతి"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "స్టాటిక్ పద్ధతి"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  str: "స్ట్రింగ్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "స్ట్రింగ్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  sum: "మొత్తం"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "మొత్తం"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan looks fine
+    # ✅ @sh1fu-X
+  super: "సూపర్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "సూపర్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  tuple: "టుపుల్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "టుపుల్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  type: "రకం"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "రకం"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  vars: "వేరియబుల్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "వేరియబుల్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  zip: "జిప్"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "జిప్"
+    # ✅ @sujithkumardola
+    # ✅ @sneha-thyagarajan
+    # ✅ @sh1fu-X
+  __import__: "__దిగుమతి__"
+    # 👀 @nagendrady
+    # 👀 @manojkrishnak
+    # 👀 @Ln11211
+    # ✅ @KarthikMothiki "__దిగుమతి__"
+    # ✅ @sujithkumardola
+    # 👀 @sneha-thyagarajan
+    # ✅ @sh1fu-X
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/tl.yml
+++ b/locale/tl.yml
@@ -1,0 +1,1816 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "tl"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "tala"
+  INFO: "impormasyon"
+  IDEA: "ideya"
+  DEBUG: "debug"
+  REMOVE: "tanggalin"
+  OPTIMIZE: "optimasyon"
+  REVIEW: "rebyew"
+  HACK: "hack"
+  UNDONE: "hindi magawa"
+  TODO: "gagawin"
+  REFACTOR: "ayusin"
+  DEPRECATED: "natanggal"
+  TASK: "gawain"
+  CHGME: "chngme"
+  NOTREACHED: "di naabot"
+  WTF: "wtf"
+  BUG: "insekto"
+  ERROR: "eror"
+  OMG: "o diyos ko"
+  ERR: "err"
+  OMFGRLY: "omfgrl"
+  WARNING: "babala"
+  WARN: "balaan"
+  BROKEN: "sira"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: "abstract"
+  codata: "codata"
+  coinductive: "coinductive"
+  constructor: "tagabuo"
+  data: "data"
+  do: "gawin"
+  eta-equality: "eta-equality"
+  field: "bukid"
+  forall: "para sa lahat"
+  hiding: "nagtatago"
+  import: "angkat"
+  in: "sa"
+  inductive: "induktibo"
+  infix: "infix"
+  infixl: "infixl"
+  infixr: "infixr"
+  instance: "halimbawa"
+  let: "hayaan"
+  macro: "macro"
+  module: "modyul"
+  mutual: "kapwa"
+  no-eta-equality: "no-eta-equality"
+  open: "bukas"
+  overlap: "magkakapatong"
+  pattern: "pattern"
+  postulate: "
+mag-post"
+  primitive: "primitive"
+  private: "pribado"
+  public: "pampubliko"
+  quote: "quote"
+  quoteContext: "quoteContext"
+  quoteGoal: "quoteGoal"
+  quoteTerm: "quoteTerm"
+  record: "talaan"
+  renaming: "renaming"
+  rewrite: "
+isulat muli"
+  Set: "Itakda" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "syntax"
+  tactic: "taktika"
+  unquote: "
+mag-unquote"
+  unquoteDecl: "unquoteDecl"
+  unquoteDef: "unquoteDef"
+  using: "gamit"
+  where: "saan"
+  with: "kasama"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "awtomatiko"
+double: "doble"
+int: "int"
+struct: "istruktura"
+break: "pahinga"
+else: "iba pa"
+long: "mahaba"
+switch: "palit"
+case: "kaso"
+enum: "enum"
+register: "rehistro"
+typedef: "typedef"
+char: "char"
+extern: "extern"
+return: "bumalik"
+union: "unyon"
+const: "const"
+float: "lumutang"
+short: "maikli"
+unsigned: "unsigned"
+continue: "magpatuloy"
+for: "para sa"
+signed: "signed"
+void: "walang bisa"
+default: "default"
+goto: "goto"
+sizeof: "sizeof"
+volatile: "volatile"
+do: "gawin"
+if: "kung"
+static: "static"
+while: "habang"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: "agumento"
+await: "naghihintay"
+break: "pahinga"
+case: "kaso"
+catch: "mahuli"
+class: "klase"
+const: "const"
+continue: "magpatuloy"
+debugger: "debugger"
+default: "default"
+delete: "tanggalin"
+do: "gawin"
+else: "iba pa"
+enum: "enum"
+eval: "eval"
+export: "export"
+extends: "nagpapalawak"
+false: "mali"
+finally: "sa wakas"
+for: "para sa"
+from: "mula sa"
+function: "pag andar"
+if: "kung"
+implements: "nagpapatupad"
+import: "angkat"
+in: "sa"
+instanceof: "instanceof"
+interface: "interface"
+let: "hayaan"
+new: "bago"
+null: "wala"
+package: "package"
+private: "pribado"
+protected: "protektado"
+public: "pampubliko"
+return: "bumalik"
+static: "static"
+super: "super"
+switch: "lumipat"
+this: "eto"
+throw: "ibato"
+true: "totoo"
+try: "subukan"
+typeof: "typeof"
+var: "var"
+void: "walang bisa"
+while: "habang"
+with: "kasma"
+yield: "ani"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: "schema"
+$ref: "ref"
+$id: "id"
+$comment: "puna"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: "__dirname"
+__filename: "__filename"
+exports: "pag-export"
+module: "modyul"
+require: "nangangailangan" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "mali" ✅
+  None: "wala" ✅
+  True: "totoo" ✅
+  and: "at" ✅
+  as: "bilang" ✅
+  assert: "igiit" ✅
+  async: "async" ✅
+  await: "naghihintay" ✅
+  break: "hinto" ❓ # tigil might be a better alternative
+  class: "klase" ✅
+  continue: "magpatuloy" ✅
+  def: "def" ✅
+  del: "del" ✅
+  elif: "elif" ✅
+  else: "iba pa" ✅
+  except: "maliban" ✅
+  finally: "sa wakas" ❓ # sa huli might be a better alternative
+  for: "para sa" ✅
+  from: "mula sa" ✅
+  global:  "global" ✅
+  if: "kung" ✅
+  import: "angkat" 🤔 # import works for the context used in Python, angkat is not widely used anymore
+  in: "sa" ✅
+  is: "ay" ✅
+  lambda: "lambda" ✅
+  nonlocal: "nonlocal" ✅
+  not: "hindi" ✅
+  or: "o" ✅
+  pass: "pumasa" ✅
+  raise: "itaas" ✅
+  return: "bumalik" ✅
+  try: "subukan" ✅
+  while: "habang" ✅
+  with: "kasama" ✅
+  yield: "ani" ✅
+
+# << Built-In Functions >>
+
+  abs: "abs"
+  all: "lahat"
+  any: "anumang"
+  ascii: "ascii"
+  bin: "bin"
+  bool: "bool"
+  breakpoint: "breakpoint"
+  bytearray: "bytearray"
+  bytes: "bytes"
+  callable: "natatawag"
+  chr: "chr"
+  classmethod: "classmethod"
+  compile: "compile"
+  complex: "kumplikado"
+  delattr: "delattr"
+  dict: "dict"
+  dir: "dir"
+  divmod: "divmod"
+  enumerate: "magtala"
+  eval: "eval"
+  exec: "exec"
+  filter: "salain"
+  float: "float"
+  format: "format"
+  frozenset: "frozenset"
+  getattr: "getattr"
+  globals: "globals"
+  hasattr: "hasattr"
+  hash: "hash"
+  help: "tumulong"
+  hex: "hex"
+  id: "id"
+  input: "input"
+  int: "int"
+  isinstance: "isinstance"
+  issubclass: "issubclass"
+  iter: "iter"
+  len: "len"
+  list: "list"
+  locals: "locals"
+  map: "map"
+  max: "pinakamataas"
+  memoryview: "memoryview"
+  min: "pinakamaliit"
+  next: "susunod"
+  object: "bagay"
+  oct: "oct"
+  open: "bukas"
+  ord: "ord"
+  pow: "pow"
+  print: "print"
+  property: "katangian"
+  range: "saklaw"
+  repr: "repr"
+  reversed: "baligtad"
+  round: "round"
+  set: "set"
+  setattr: "setattr"
+  slice: "hiwain"
+  sorted: "pinagsunod-sunod"
+  staticmethod: ""
+  str: "str"
+  sum: "suma"
+  super: "super"
+  tuple: "tuple"
+  type: "uri"
+  vars: "vars"
+  zip: "zip"
+  __import__: "__import__"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: "alyas"
+and: "at"
+begin: "magsimula"
+break: "pahinga"
+case: "kaso"
+class: "klase"
+def: "def"
+defined?: "defined?"
+do: "gawin"
+else: "iba pa"
+elsif: "kung hindi man"
+end: "wakas"
+ensure: "ensure"
+false: "mali"
+for: "para sa"
+if: "kung"
+in: "in"
+module: "modyul"
+next: "sunod"
+nil: "nil"
+not: "hindi"
+or: "o"
+redo: "redo"
+rescue: "pagsagip"
+retry: "subukan"
+return: "bumalik"
+self: "sarili"
+super: "super"
+then: "pagkatapos"
+true: "totoo"
+undef: "undef"
+unless: "maliban kung"
+until: "hanggang"
+when: "kailan"
+while: "habang"
+yield: "ani"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>

--- a/locale/tr.yml
+++ b/locale/tr.yml
@@ -1,0 +1,1748 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "tr"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "NOT"
+  INFO: "BİLGİ"
+  IDEA: "FİKİR"
+  DEBUG: "HATA AYIKLAMA"
+  REMOVE: "SİL"
+  OPTIMIZE: "AYARLA"
+  REVIEW: "DEĞERLENDİR"
+  HACK: ""
+  UNDONE: "GERİ AL"
+  TODO: "YAPACAKLAR"
+  REFACTOR: "YENİDEN DÜZENLEME"
+  DEPRECATED: "KULLANIMDAN KALDIRILDI"
+  TASK: "GÖREV"
+  CHGME: ""
+  NOTREACHED: "ULAŞILAMADI"
+  WTF: "ANANI SİKİYİM"
+  BUG: ""
+  ERROR: "HATA"
+  OMG: "HASSİKTİR"
+  ERR: "HATA"
+  OMFGRLY: "HASSİKTİR"
+  WARNING: "UYARI"
+  WARN: "UYARI"
+  BROKEN: "KIRIK"
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: "soyut"
+  codata: "coveri"
+  coinductive: ""
+  constructor: ""
+  data: "veri"
+  do: ""
+  eta-equality: ""
+  field: "alan"
+  forall: ""
+  hiding: "gizlemek"
+  import: "içe aktar"
+  in: "içinde"
+  inductive: "tümevarımsal"
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: "durum"
+  let: "izin ver"
+  macro: "makro"
+  module: "modül"
+  mutual: "müşterek"
+  no-eta-equality: ""
+  open: "açık"
+  overlap: "aşmak"
+  pattern: "desen"
+  postulate: "koyut"
+  primitive: "ilkel"
+  private: "özel"
+  public: "halka açık"
+  quote: "alıntı"
+  quoteContext: "alıntıBağlam"
+  quoteGoal: "alıntıAmaç"
+  quoteTerm: "alıntıTerm"
+  record: "kayıt"
+  renaming: "yeniden adlandırmak"
+  rewrite: "üstüne yazma"
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: "sözdizimi"
+  tactic: "taktik"
+  unquote: "alıntıyı bırak"
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: "kullanıyor"
+  where: "nerede"
+  with: "ile"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "yap" # (part of do-while statement)
+while: "o arada"
+for: "için"
+if: "eğer" # (part of if-else statement)
+else: "öbür türlü" # (part of if-else statement)
+switch: "değiştir"
+break: "dur" # (part of the switch statement or for/while statements)
+case: "durum" # (part of the switch statement)
+continue: "devam et" # (part of for/while statements)
+default: "varsayılan" # (part of switch statement)
+function: "fonksiyon"
+procedure: "prosedür"
+return: "geri"
+local: "lokal"
+global: ""
+static: "statik"
+typeof: "şu tür"
+NOT: "DEĞİL"
+AND: "VE"
+OR: "VEYA"
+Null: "Sıfır"
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: "durum"
+do: "yap"
+done: "yapıldı"
+elif: "eğer öbür türlü"
+else: "öbür türlü"
+esac: ""
+fi: ""
+for: "için"
+function: "fonksiyon"
+if: "eğer"
+in: "içinde"
+select: "seç"
+then: "sonra"
+time: "zaman"
+until: "şuna kadar"
+while: "o arada"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: ""
+  None: ""
+  True: ""
+  and: ""
+  as: ""
+  assert: ""
+  async: ""
+  await: ""
+  break: ""
+  class: ""
+  continue: ""
+  def: ""
+  del: ""
+  elif: ""
+  else: ""
+  except: ""
+  finally: ""
+  for: ""
+  from: ""
+  global:  ""
+  if: ""
+  import: ""
+  in: ""
+  is: ""
+  lambda: ""
+  nonlocal: ""
+  not: ""
+  or: ""
+  pass: ""
+  raise: ""
+  return: ""
+  try: ""
+  while: ""
+  with: ""
+  yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/uk.yml
+++ b/locale/uk.yml
@@ -1,0 +1,1834 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "uk"
+
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: "ПРИМІТКА"✅ 
+  INFO: "ІНФО"❓[another possible translation: "ІНФОРМАЦІЯ"]
+  IDEA: "ІДЕЯ"✅ 
+  DEBUG: "ВІДЛАГОДЖУВАТИ"✅ 
+  REMOVE: "ВИДАЛИТИ"✅ 
+  OPTIMIZE: "ОПТИМІЗУВАТИ"✅ 
+  REVIEW: "ОГЛЯД"✅ 
+  HACK: "ВЗЛАМАТИ"✅ 
+  UNDONE: "НЕВИКОНАНО"✅ 
+  TODO: "ВИКОНАТИ"✅ 
+  REFACTOR: "РЕФАКТОР"✅ 
+  DEPRECATED: "ВИВЕДЕНИЙЗЛАДУ"❓[another possible translation: "ЗАСТАРІЛИЙ"]
+  TASK: "ЗАВДАННЯ"✅ 
+  CHGME: "CHGME"🤔
+  NOTREACHED: "НЕДОСЯГАЙМИЙ"❓[a more proper form of translation: "НЕДОСЯЖНИЙ"/"ПОЗА ВИДИМІСТЮ"]
+  WTF: "WTF"🤔
+  BUG: "БАГ"✅ 
+  ERROR: "ПОМИЛКА"✅ 
+  OMG: "OMG"🤔
+  ERR: "ПОМИЛКА"✅ 
+  OMFGRLY: "OMFGRLY"🤔
+  WARNING: "УВАГА"✅
+  WARN: "ПОПЕРЕДИТИ"✅ 
+  BROKEN: "ЗЛАМАНИЙ"✅ 
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: "авто"
+double: "двійне_ціле_число"
+int: "ціле_число"
+struct: "структура"
+break: "переривати"
+else: "тоді"
+long: "довге_ціле_число"
+switch: "перемикач"
+case: "випадок"
+enum: "перерахувати"
+register: "реєструвати"
+typedef: "визначення_типу"
+char: "символ"
+extern: "зовнішній"
+return: "вернути"
+union: "об'єднання"
+const: "константа"
+float: "тип_з_плаваючою_крапкою"
+short: "коротке_ціле_число"
+unsigned: "без_знаковий_тип"
+continue: "продовжити"
+for: "для"
+signed: "знаковий_тип"
+void: "пустий"
+default: "за_замовчуванням"
+goto: "перейти_до"
+sizeof: "розмір"
+volatile: "непостійний"
+do: "робити"
+if: "якщо"
+static: "статичний"
+while: "доки"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# A few notes:
+# 1) Verb-based keywords were translated in infinitive form, but 
+# perhaps second person form could also be tried to keep the 
+# "conversation flow" of Python.
+#
+# 2) Ukrainian nouns and adjectives have feminine/masculine/neutral
+# forms (similar to French) as well as plural forms. So I chose the 
+# form for noun and adjective based keywords on case-by-case basis.
+#
+# 3) In order for keywords and built-in functions to make sense 
+# in Ukrainian, it requires longer notations that probably could be 
+# shortened, but that may impact readability for a learner and make
+# it yet harder to understand.
+
+# << Keywords >>
+  False: "хибність" # can also be "хиба"
+  None: "нічого"
+  True: "істина"
+  and: "і"
+  as: "як"
+  assert: "перевірити"
+  async: "асинхронно" # can also be "корутинно"
+  await: "очікувати"
+  break: "перервати"
+  class: "клас"
+  continue: "продовжити"
+  def: "оголосити"
+  del: "видалити" # can also be "видал"
+  elif: "інакше_якщо"
+  else: "інакше"
+  except: "перехопити"
+  finally: "зрештою" # can also be "в_будь_якому_випадку"
+  for: "для_кожного" # can also be "для"
+  from: "з"
+  global:  "глобальна"
+  if: "якщо"
+  import: "імпортувати" # can also be "імпорт"
+  in: "у"
+  is: "є"
+  lambda: "лямбда"
+  nonlocal: "нелокальна"
+  not: "не"
+  or: "або"
+  pass: "пропустити"
+  raise: "підняти"
+  return: "повернути"
+  try: "спробувати"
+  while: "поки"
+  with: "з_допомогою"
+  yield: "видати"
+
+# << Built-In Functions >>
+
+  abs: "абсолютне_значення" # can also be "абс"
+  all: "всі"
+  any: "будь_які"
+  ascii: "ascii"
+  bin: "бінарне"
+  bool: "булеве" # can also be "булеве_значення"
+  breakpoint: "точка_переривання"
+  bytearray: "масив_байтів"
+  bytes: "байти"
+  callable: "можна_викликати" # can also be "підтримує_виклик"
+  chr: "символ"
+  classmethod: "метод_класу"
+  compile: "компілювати"
+  complex: "комплексне"
+  delattr: "видалити_атрибут" # can also be "видалити_поле"
+  dict: "словник"
+  dir: "директорія" # can also be "дир"
+  divmod: "ділення_націло" # can also be "діл_націло"
+  enumerate: "перерахувати"
+  eval: "обчислити"
+  exec: "виконати"
+  filter: "фільтрувати"
+  float: "дійсне_число"
+  format: "форматувати"
+  frozenset: "заморожена_множина"
+  getattr: "отримати_атрибут" # can also be "отримати_поле"
+  globals: "глобальні"
+  hasattr: "має_атрибут" # can also be "має_поле"
+  hash: "закодувати"
+  help: "допомога"
+  hex: "шістнадцяткове" # can also be "шістнадцяткове_значення" 
+  id: "ід" # can also be "ідентифікатор"
+  input: "введення"
+  int: "ціле_число"
+  isinstance: "є_екземпляром"
+  issubclass: "є_підкласом"
+  iter: "ітератор" # can also be "ітер"
+  len: "довжина"
+  list: "список"
+  locals: "локальні"
+  map: "мапувати"
+  max: "максимальне" # can also be "макс"
+  memoryview: "огляд_памяті"
+  min: "мінімальне" # can also be "мін"
+  next: "наступне"
+  object: "обєкт"
+  oct: "вісімкове" # can also be "вісімкове_значення"
+  open: "відкрити"
+  ord: "код_символа"
+  pow: "ступінь"
+  print: "друкувати"
+  property: "властивість"
+  range: "діапазон"
+  repr: "представити" # can also be "формальне_рядкове_представлення"
+  reversed: "зворотній" # can also be "у_зворотньому_порядку"
+  round: "округлити"
+  set: "множина"
+  setattr: "присвоїти_атрибут" # can also be"присвоїти_поле"
+  slice: "відрізок"
+  sorted: "відсортований"
+  staticmethod: "статичний_метод"
+  str: "рядок"
+  sum: "сума"
+  super: "" # this one is difficult for me, perhaps can be "наслідувати_існуючий_метод"
+  tuple: "кортеж"
+  type: "тип"
+  vars: "змінні"
+  zip: "поєднати_в_кортеж"
+  __import__: "__імпортувати__"
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/xh.yml
+++ b/locale/xh.yml
@@ -1,0 +1,1820 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "xh"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: "Xhoka"
+  None: "Ayikho"
+  True: "Nyaniso"
+  and: "kwaye"
+  as: "xa"
+  assert: "banga"
+  async: ""
+  await: "lindela"
+  break: "phuma"
+  class: "iklasi"
+  continue: "qhubeka"
+  def: "chaza"
+  del: "cima"
+  elif: "enye"
+  else: "okanye"
+  except: "ngaphandle"
+  finally: "okugqibela"
+  for: ""
+  from: "ukusuka"
+  global:  "jikelele"
+  if: "ukuba"
+  import: "ngenisa"
+  in: "phakathi"
+  is: "yi"
+  lambda: ""
+  nonlocal: ""
+  not: "hayi"
+  or: "okanye"
+  pass: "dlula"
+  raise: "phakamisa"
+  return: "buya"
+  try: "zama"
+  while: "ngelixa"
+  with: "nge"
+  yield: "velisa"
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: "zonke"
+  any: "nayiphi"
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: "qhawula"
+  bytearray: ""
+  bytes: ""
+  callable: "iyabizwa"
+  chr: ""
+  classmethod: ""
+  compile: "qokelela"
+  complex: "inzima"
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: "hluza"
+  float: "ukuntywila"
+  format: "ukumila"
+  frozenset: "yomkhence"
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: "dincede"
+  hex: ""
+  id: ""
+  input: "igalelo"
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: "ubude"
+  list: "uluhlu"
+  locals: "bendawo"
+  map: "imephu"
+  max: "ninzi"
+  memoryview: "imemori"
+  min: "ncinci"
+  next: "landela"
+  object: "into"
+  oct: ""
+  open: "open"
+  ord: ""
+  pow: ""
+  print: "shicilela"
+  property: "propathi"
+  range: "uluhlu"
+  repr: "emele"
+  reversed: "ibuyisiwe"
+  round: "jikeleza"
+  set: "iseti"
+  setattr: ""
+  slice: "isilayi"
+  sorted: "lungisa"
+  staticmethod: ""
+  str: "umtya"
+  sum: "yongeza"
+  super: "balasele"
+  tuple: ""
+  type: "uhlobo"
+  vars: "hluka"
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>
+
+# ------------------------------------
+# |   CONTENT: LEGESHER.IO WEBSITE   |
+# ------------------------------------
+# TODO: add home page translations
+# TODO: add tutorials
+# TODO: add other content

--- a/locale/zh.yml
+++ b/locale/zh.yml
@@ -1,0 +1,1813 @@
+# Files in the locale directory are used for localization.
+# If you want to use locales other than English, follow the instructions in legesher-translations guide.
+# https://legesher.readme.io/docs/translation-guide
+#
+# THANK YOU FOR MAKING LEGESHER LARGER THAN US.
+
+# NOTE: "language-abbreviation"
+language-abbreviation: "zh"
+
+# ----------------------
+# |    SYSTEM: ATOM    |
+# ----------------------
+# << Keywords >>
+# NOTE: All keywords are capitalized for Atom because it is used for
+# key information found in comments within the editor
+  NOTE: ""
+  INFO: ""
+  IDEA: ""
+  DEBUG: ""
+  REMOVE: ""
+  OPTIMIZE: ""
+  REVIEW: ""
+  HACK: ""
+  UNDONE: ""
+  TODO: ""
+  REFACTOR: ""
+  DEPRECATED: ""
+  TASK: ""
+  CHGME: ""
+  NOTREACHED: ""
+  WTF: ""
+  BUG: ""
+  ERROR: ""
+  OMG: ""
+  ERR: ""
+  OMFGRLY: ""
+  WARNING: ""
+  WARN: ""
+  BROKEN: ""
+
+# ----------------------
+# |   LANGUAGE: AGDA   |
+# ----------------------
+# NOTE: https://agda.readthedocs.io/en/v2.5.4.2/index.html
+# << Keywords >>
+  abstract: ""
+  codata: ""
+  coinductive: ""
+  constructor: ""
+  data: ""
+  do: ""
+  eta-equality: ""
+  field: ""
+  forall: ""
+  hiding: ""
+  import: ""
+  in: ""
+  inductive: ""
+  infix: ""
+  infixl: ""
+  infixr: ""
+  instance: ""
+  let: ""
+  macro: ""
+  module: ""
+  mutual: ""
+  no-eta-equality: ""
+  open: ""
+  overlap: ""
+  pattern: ""
+  postulate: ""
+  primitive: ""
+  private: ""
+  public: ""
+  quote: ""
+  quoteContext: ""
+  quoteGoal: ""
+  quoteTerm: ""
+  record: ""
+  renaming: ""
+  rewrite: ""
+  Set: "" # can appear with a number suffix, optionally suffixed, make sure we account for this
+  syntax: ""
+  tactic: ""
+  unquote: ""
+  unquoteDecl: ""
+  unquoteDef: ""
+  using: ""
+  where: ""
+  with: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: AFL    |
+# ----------------------
+# Amibroker Formula Language
+# NOTE: https://www.amibroker.com/guide/a_language.html
+
+# << Keywords >>
+do: "" # (part of do-while statement)
+while: ""
+for: ""
+if: "" # (part of if-else statement)
+else: "" # (part of if-else statement)
+switch: ""
+break: "" # (part of the switch statement or for/while statements)
+case: "" # (part of the switch statement)
+continue: "" # (part of for/while statements)
+default: "" # (part of switch statement)
+function: ""
+procedure: ""
+return: ""
+local: ""
+global: ""
+static: ""
+typeof: ""
+NOT: ""
+AND: ""
+OR: ""
+Null: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: BASH   |
+# ----------------------
+# << Keywords >>
+case: ""
+do: ""
+done: ""
+elif: ""
+else: ""
+esac: ""
+fi: ""
+for: ""
+function: ""
+if: ""
+in: ""
+select: ""
+then: ""
+time: ""
+until: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C      |
+# ----------------------
+# << Keywords >>
+auto: ""
+double: ""
+int: ""
+struct: ""
+break: ""
+else: ""
+long: ""
+switch: ""
+case: ""
+enum: ""
+register: ""
+typedef: ""
+char: ""
+extern: ""
+return: ""
+union: ""
+const: ""
+float: ""
+short: ""
+unsigned: ""
+continue: ""
+for: ""
+signed: ""
+void: ""
+default: ""
+goto: ""
+sizeof: ""
+volatile: ""
+do: ""
+if: ""
+static: ""
+while: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  C++   |
+# ----------------------
+# << Keywords >>
+
+#define: ""
+#defined: ""
+#elif: ""
+#else: ""
+#endif: ""
+#error: ""
+#if: ""
+#ifdef: ""
+#ifndef: ""
+#include: ""
+#line: ""
+#pragma: ""
+#undef: ""
+alignas: ""
+alignof: ""
+and: ""
+and_eq: ""
+asm: ""
+atomic_cancel: ""
+atomic_commit: ""
+atomic_noexcept: ""
+auto: ""
+bitand: ""
+bitor: ""
+bool: ""
+break: ""
+case: ""
+catch: ""
+char: ""
+char16_t: ""
+char32_t: ""
+class: ""
+compl: ""
+concept: ""
+const: ""
+constexpr: ""
+const_cast: ""
+continue: ""
+decltype: ""
+default: ""
+delete: ""
+do: ""
+double: ""
+dynamic_cast: ""
+else: ""
+enum: ""
+explicit: ""
+export: ""
+extern: ""
+false: ""
+final: ""
+float: ""
+for: ""
+friend: ""
+goto: ""
+if: ""
+inline: ""
+int: ""
+import: ""
+long: ""
+module: ""
+mutable: ""
+namespace: ""
+new: ""
+noexcept: ""
+not: ""
+not_eq: ""
+nullptr: ""
+operator: ""
+or: ""
+or_eq: ""
+override: ""
+private: ""
+protected: ""
+public: ""
+register: ""
+reinterpret_cast: ""
+requires: ""
+return: ""
+short: ""
+signed: ""
+sizeof: ""
+static: ""
+static_assert: ""
+static_cast: ""
+struct: ""
+switch: ""
+synchronized: ""
+template: ""
+this: ""
+thread_local: ""
+throw: ""
+transaction_safe: ""
+transaction_safe_dynamic: ""
+true: ""
+try: ""
+typedef: ""
+typeid: ""
+typename: ""
+union: ""
+unsigned: ""
+using: ""
+virtual: ""
+void: ""
+volatile: ""
+wchar_t: ""
+while: ""
+xor: ""
+xor_eq: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: C#     |
+# ----------------------
+# << Keywords >>
+abstract: ""
+add: ""
+alias: ""
+as: ""
+ascending: ""
+async: ""
+await: ""
+base: ""
+bool: ""
+break: ""
+byte: ""
+case: ""
+catch: ""
+char: ""
+checked: ""
+class: ""
+const: ""
+continue: ""
+decimal: ""
+default: ""
+delegate: ""
+descending: ""
+do: ""
+double: ""
+dynamic: ""
+else: ""
+enum: ""
+event: ""
+explicit: ""
+extern: ""
+false: ""
+finally: ""
+fixed: ""
+float: ""
+for: ""
+foreach: ""
+from: ""
+get: ""
+global: ""
+goto: ""
+group: ""
+if: ""
+implicit: ""
+in: ""
+int: ""
+interface: ""
+internal: ""
+into: ""
+is: ""
+join: ""
+let: ""
+lock: ""
+long: ""
+namespace: ""
+new: ""
+null: ""
+object: ""
+operator: ""
+orderby: ""
+out: ""
+override: ""
+params: ""
+partial: ""
+private: ""
+protected: ""
+public: ""
+readonly: ""
+ref: ""
+remove: ""
+return: ""
+sbyte: ""
+sealed: ""
+select: ""
+set: ""
+short: ""
+sizeof: ""
+stackalloc: ""
+static: ""
+string: ""
+struct: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+uint: ""
+ulong: ""
+unchecked: ""
+unsafe: ""
+ushort: ""
+using: ""
+value: ""
+var: ""
+virtual: ""
+void: ""
+volatile: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: CSS    |
+# ----------------------
+# This regex saved by butt: FIND = \n(@?)(\w+)(-\w+){0,3} REPLACE: \n$1$2$3: "" #
+
+# << Keywords >>
+align-content: "" #	Specifies the alignment between the lines inside a flexible container when the items do not use all available space
+align-items: "" #	Specifies the alignment for items inside a flexible container
+align-self: "" #	Specifies the alignment for selected items inside a flexible container
+all: "" #	Resets all properties (except unicode-bidi and direction)
+animation: "" #	A shorthand property for all the animation-* properties
+animation-delay: "" #	Specifies a delay for the start of an animation
+animation-direction: "" #	Specifies whether an animation should be played forwards, backwards or in alternate cycles
+animation-duration: "" #	Specifies how long an animation should take to complete one cycle
+animation-mode: "" #	Specifies a style for the element when the animation is not playing (before it starts, after it ends, or both)
+animation-count: "" #	Specifies the number of times an animation should be played
+animation-name: "" #	Specifies a name for the @keyframes animation
+animation-state: "" #	Specifies whether the animation is running or paused
+animation-function: "" #	Specifies the speed curve of an animation
+backface-visibility: "" #	Defines whether or not the back face of an element should be visible when facing the user
+background: "" #	A shorthand property for all the background-* properties
+background-attachment: "" #	Sets whether a background image scrolls with the rest of the page, or is fixed
+background-mode: "" #	Specifies the blending mode of each background layer (color/image)
+background-clip: "" #	Defines how far the background (color or image) should extend within an element
+background-color: "" #	Specifies the background color of an element
+background-image: "" #	Specifies one or more background images for an element
+background-origin: "" #	Specifies the origin position of a background image
+background-position: "" #	Specifies the position of a background image
+background-repeat: "" #	Sets if/how a background image will be repeated
+background-size: "" #	Specifies the size of the background images
+border: "" #	A shorthand property for border-width, border-style and border-color
+border-bottom: "" #	A shorthand property for border-bottom-width, border-bottom-style and border-bottom-color
+border-color: "" #	Sets the color of the bottom border
+border-radius: "" #	Defines the radius of the border of the bottom-left corner
+border-radius: "" #	Defines the radius of the border of the bottom-right corner
+border-style: "" #	Sets the style of the bottom border
+border-width: "" #	Sets the width of the bottom border
+border-collapse: "" #	Sets whether table borders should collapse into a single border or be separated
+border-color: "" #	Sets the color of the four borders
+border-image: "" #	A shorthand property for all the border-image-* properties
+border-outset: "" #	Specifies the amount by which the border image area extends beyond the border box
+border-repeat: "" #	Specifies whether the border image should be repeated, rounded or stretched
+border-slice: "" #	Specifies how to slice the border image
+border-source: "" #	Specifies the path to the image to be used as a border
+border-width: "" #	Specifies the width of the border image
+border-left: "" #	A shorthand property for all the border-left-* properties
+border-color: "" #	Sets the color of the left border
+border-style: "" #	Sets the style of the left border
+border-width: "" #	Sets the width of the left border
+border-radius: "" #	A shorthand property for the four border-*-radius properties
+border-right: "" #	A shorthand property for all the border-right-* properties
+border-color: "" #	Sets the color of the right border
+border-style: "" #	Sets the style of the right border
+border-width: "" #	Sets the width of the right border
+border-spacing: "" #	Sets the distance between the borders of adjacent cells
+border-style: "" #	Sets the style of the four borders
+border-top: "" #	A shorthand property for border-top-width, border-top-style and border-top-color
+border-color: "" #	Sets the color of the top border
+border-radius: "" #	Defines the radius of the border of the top-left corner
+border-radius: "" #	Defines the radius of the border of the top-right corner
+border-style: "" #	Sets the style of the top border
+border-width: "" #	Sets the width of the top border
+border-width: "" #	Sets the width of the four borders
+bottom: "" #	Sets the elements position, from the bottom of its parent element
+box-break: "" #	Sets the behavior of the background and border of an element at page-break, or, for in-line elements, at line-break.
+box-shadow: "" #	Attaches one or more shadows to an element
+box-sizing: "" #	Defines how the width and height of an element are calculated: should they include padding and borders, or not
+break-after: "" #	Specifies the page-, column-, or region-break behavior after the generated box
+break-before: "" #	Specifies the page-, column-, or region-break behavior before the generated box
+break-inside: "" #	Specifies the page-, column-, or region-break behavior inside the generated box
+caption-side: "" #	Specifies the placement of a table caption
+caret-color: "" #	Specifies the color of the cursor (caret) in inputs, textareas, or any element that is editable
+@charset: "" #	Specifies the character encoding used in the style sheet
+clear: "" #	Specifies on which sides of an element floating elements are not allowed to float
+clip: "" #	Clips an absolutely positioned element
+color: "" #	Sets the color of text
+column-count: "" #	Specifies the number of columns an element should be divided into
+column-fill: "" #	Specifies how to fill columns, balanced or not
+column-gap: "" #	Specifies the gap between the columns
+column-rule: "" #	A shorthand property for all the column-rule-* properties
+column-color: "" #	Specifies the color of the rule between columns
+column-style: "" #	Specifies the style of the rule between columns
+column-width: "" #	Specifies the width of the rule between columns
+column-span: "" #	Specifies how many columns an element should span across
+column-width: "" #	Specifies the column width
+columns: "" #	A shorthand property for column-width and column-count
+content: "" #	Used with the :before and :after pseudo-elements, to insert generated content
+counter-increment: "" #	Increases or decreases the value of one or more CSS counters
+counter-reset: "" #	Creates or resets one or more CSS counters
+cursor: "" #	Specifies the mouse cursor to be displayed when pointing over an element
+direction: "" #	Specifies the text direction/writing direction
+display: "" #	Specifies how a certain HTML element should be displayed
+empty-cells: "" #	Specifies whether or not to display borders and background on empty cells in a table
+filter: "" #	Defines effects (e.g. blurring or color shifting) on an element before the element is displayed
+flex: "" #	A shorthand property for the flex-grow, flex-shrink, and the flex-basis properties
+flex-basis: "" #	Specifies the initial length of a flexible item
+flex-direction: "" #	Specifies the direction of the flexible items
+flex-flow: "" #	A shorthand property for the flex-direction and the flex-wrap properties
+flex-grow: "" #	Specifies how much the item will grow relative to the rest
+flex-shrink: "" #	Specifies how the item will shrink relative to the rest
+flex-wrap: "" #	Specifies whether the flexible items should wrap or not
+float: "" #	Specifies whether or not a box should float
+font: "" #	A shorthand property for the font-style, font-variant, font-weight, font-size/line-height, and the font-family properties
+@font-face: "" #	A rule that allows websites to download and use fonts other than the "web-safe" fonts
+font-family: "" #	Specifies the font family for text
+font-settings: "" #	Allows control over advanced typographic features in OpenType fonts
+@font-values: "" #	Allows authors to use a common name in font-variant-alternate for feature activated differently in OpenType
+font-kerning: "" #	Controls the usage of the kerning information (how letters are spaced)
+font-override: "" #	Controls the usage of language-specific glyphs in a typeface
+font-size: "" #	Specifies the font size of text
+font-adjust: "" #	Preserves the readability of text when font fallback occurs
+font-stretch: "" #	Selects a normal, condensed, or expanded face from a font family
+font-style: "" #	Specifies the font style for text
+font-synthesis: "" #	Controls which missing typefaces (bold or italic) may be synthesized by the browser
+font-variant: "" #	Specifies whether or not a text should be displayed in a small-caps font
+font-alternates: "" #	Controls the usage of alternate glyphs associated to alternative names defined in @font-feature-values
+font-caps: "" #	Controls the usage of alternate glyphs for capital letters
+font-asian: "" #	Controls the usage of alternate glyphs for East Asian scripts (e.g Japanese and Chinese)
+font-ligatures: "" #	Controls which ligatures and contextual forms are used in textual content of the elements it applies to
+font-numeric: "" #	Controls the usage of alternate glyphs for numbers, fractions, and ordinal markers
+font-position: "" #	Controls the usage of alternate glyphs of smaller size positioned as superscript or subscript regarding the baseline of the font
+font-weight: "" #	Specifies the weight of a font
+grid: "" #  A shorthand property for the grid-template-rows, grid-template-columns, grid-template-areas, grid-auto-rows, grid-auto-columns, and the grid-auto-flow properties
+grid-area: "" #	Either specifies a name for the grid item, or this property is a shorthand property for the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties
+grid-columns: "" #	Specifies a default column size
+grid-flow: "" #	Specifies how auto-placed items are inserted in the grid
+grid-rows: "" #	Specifies a default row size
+grid-column: "" #	A shorthand property for the grid-column-start and the grid-column-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between columns
+grid-start: "" #	Specifies where to start the grid item
+grid-gap: "" #	A shorthand property for the grid-row-gap and grid-column-gap properties
+grid-row: "" #	A shorthand property for the grid-row-start and the grid-row-end properties
+grid-end: "" #	Specifies where to end the grid item
+grid-gap: "" #	Specifies the size of the gap between rows
+grid-start: "" #	Specifies where to start the grid item
+grid-template: "" #	A shorthand property for the grid-template-rows, grid-template-columns and grid-areas properties
+grid-areas: "" #	Specifies how to display columns and rows, using named grid items
+grid-columns: "" #	Specifies the size of the columns, and how many columns in a grid layout
+grid-rows: "" #	Specifies the size of the rows in a grid layout
+hanging-punctuation: "" #	Specifies whether a punctuation character may be placed outside the line box
+height: "" #	Sets the height of an element
+hyphens: "" #	Sets how to split words to improve the layout of paragraphs
+image-rendering: "" #	Gives a hint to the browser about what aspects of an image are most important to preserve when the image is scaled
+@import: "" #	Allows you to import a style sheet into another style sheet
+isolation: "" #	Defines whether an element must create a new stacking content
+justify-content: "" #	Specifies the alignment between the items inside a flexible container when the items do not use all available space
+@keyframes: "" #	Specifies the animation code
+left: "" #	Specifies the left position of a positioned element
+letter-spacing: "" #	Increases or decreases the space between characters in a text
+line-break: "" #	Specifies how/if to break lines
+line-height: "" #	Sets the line height
+list-style: "" #	Sets all the properties for a list in one declaration
+list-image: "" #	Specifies an image as the list-item marker
+list-position: "" #	Specifies the position of the list-item markers (bullet points)
+list-type: "" #	Specifies the type of list-item marker
+margin: "" #	Sets all the margin properties in one declaration
+margin-bottom: "" #	Sets the bottom margin of an element
+margin-left: "" #	Sets the left margin of an element
+margin-right: "" #	Sets the right margin of an element
+margin-top: "" #	Sets the top margin of an element
+max-height: "" #	Sets the maximum height of an element
+max-width: "" #	Sets the maximum width of an element
+@media: "" #	Sets the style rules for different media types/devices/sizes
+min-height: "" #	Sets the minimum height of an element
+min-width: "" #	Sets the minimum width of an element
+mix-mode: "" #	Specifies how an element's content should blend with its direct parent background
+object-fit: "" #	Specifies how the contents of a replaced element should be fitted to the box established by its used height and width
+object-position: "" #	Specifies the alignment of the replaced element inside its box
+opacity: "" #	Sets the opacity level for an element
+order: "" #	Sets the order of the flexible item, relative to the rest
+orphans: "" #	Sets the minimum number of lines that must be left at the bottom of a page when a page break occurs inside an element
+outline: "" #	A shorthand property for the outline-width, outline-style, and the outline-color properties
+outline-color: "" #	Sets the color of an outline
+outline-offset: "" #	Offsets an outline, and draws it beyond the border edge
+outline-style: "" #	Sets the style of an outline
+outline-width: "" #	Sets the width of an outline
+overflow: "" #
+Specifies: "" # what happens if content overflows an element's box
+overflow-wrap: "" #	Specifies whether or not the browser may break lines within words in order to prevent overflow (when a string is too long to fit its containing box)
+overflow-x: "" #	Specifies whether or not to clip the left/right edges of the content, if it overflows the element's content area
+overflow-y: "" #	Specifies whether or not to clip the top/bottom edges of the content, if it overflows the element's content area
+padding: "" #	A shorthand property for all the padding-* properties
+padding-bottom: "" #	Sets the bottom padding of an element
+padding-left: "" #	Sets the left padding of an element
+padding-right: "" #	Sets the right padding of an element
+padding-top: "" #	Sets the top padding of an element
+page-after: "" #	Sets the page-break behavior after an element
+page-before: "" #: "" #	Sets the page-break behavior before an element
+page-inside: "" #: "" #	Sets the page-break behavior inside an element
+perspective: "" #	Gives a 3D-positioned element some perspective
+perspective-origin: "" #	Defines at which position the user is looking at the 3D-positioned element
+pointer-events: "" #	Defines whether or not an element reacts to pointer events
+position: "" #	Specifies the type of positioning method used for an element (static, relative, absolute or fixed)
+quotes: "" #	Sets the type of quotation marks for embedded quotations
+resize: "" #	Defines if (and how) an element is resizable by the user
+right: "" #	Specifies the right position of a positioned element
+scroll-behavior: "" #	Specifies whether to smoothly animate the scroll position in a scrollable box, instead of a straight jump
+tab-size: "" #	Specifies the width of a tab character
+table-layout: "" #	Defines the algorithm used to lay out table cells, rows, and columns
+text-align: "" #	Specifies the horizontal alignment of text
+text-last: "" #	Describes how the last line of a block or a line right before a forced line break is aligned when text-align is "justify"
+text-upright: "" #	Specifies the combination of multiple characters into the space of a single character
+text-decoration: "" #	Specifies the decoration added to text
+text-color: "" #	Specifies the color of the text-decoration
+text-line: "" #	Specifies the type of line in a text-decoration
+text-style: "" #	Specifies the style of the line in a text decoration
+text-indent: "" #	Specifies the indentation of the first line in a text-block
+text-justify: "" #	Specifies the justification method used when text-align is "justify"
+text-orientation: "" #: "" 	#Defines the orientation of the text in a line
+text-overflow: "" #: "" 	#Specifies what should happen when text overflows the containing element
+text-shadow: "" #: "" 	#Adds shadow to text
+text-transform: "" #: "" 	#Controls the capitalization of text
+text-position: "" #: "" #	Specifies the position of the underline which is set using the text-decoration property
+top: "" #: "" #	Specifies the top position of a positioned element
+transform: "" #: "" #	Applies a 2D or 3D transformation to an element
+transform-origin: "" #	Allows you to change the position on transformed elements
+transform-style: "" #	Specifies how nested elements are rendered in 3D space
+transition: "" #	A shorthand property for all the transition-* properties
+transition-delay: "" #	Specifies when the transition effect will start
+transition-duration: "" #	Specifies how many seconds or milliseconds a transition effect takes to complete
+transition-property: "" #	Specifies the name of the CSS property the transition effect is for
+transition-function: "" #	Specifies the speed curve of the transition effect
+unicode-bidi: "" #	Used together with the direction property to set or return whether the text should be overridden to support multiple languages in the same document
+user-select: "" #	Specifies whether the text of an element can be selected
+vertical-align: "" #	Sets the vertical alignment of an element
+visibility: "" #	Specifies whether or not an element is visible
+white-space: "" #	Specifies how white-space inside an element is handled
+widows: "" #	Sets the minimum number of lines that must be left at the top of a page when a page break occurs inside an element
+width: "" #	Sets the width of an element
+word-break: "" #	Specifies how words should break when reaching the end of a line
+word-spacing: "" #	Increases or decreases the space between words in a text
+word-wrap: "" #	Allows long, unbreakable words to be broken and wrap to the next line
+writing-mode: "" #	Specifies whether lines of text are laid out horizontally or vertically
+z-index: "" #	Sets the stack order of a positioned element
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: FLUENT   |
+# ------------------------
+# << Keywords >>
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: GOLANG   |
+# ------------------------
+# << Keywords >>
+break: ""
+default: ""
+func: ""
+interface: ""
+select: ""
+case: ""
+defer: ""
+go: ""
+map: ""
+struct: ""
+chan: ""
+else: ""
+goto: ""
+package: ""
+switch: ""
+const: ""
+fallthrough: ""
+if: ""
+range: ""
+type: ""
+continue: ""
+for: ""
+import: ""
+return: ""
+var: ""
+
+# << Error Messages >>
+
+# -------------------------
+# |   LANGUAGE: HASKELL   |
+# -------------------------
+# << Keywords >>
+as: ""
+case: ""
+of: ""
+class: ""
+data: ""
+data family: ""
+data instance: ""
+default: ""
+deriving: ""
+deriving instance: ""
+do: ""
+forall: ""
+foreign: ""
+hiding: ""
+if: ""
+then: ""
+else: ""
+import: ""
+infix: ""
+infixl: ""
+infixr: ""
+instance: ""
+let: ""
+in: ""
+mdo: ""
+module: ""
+newtype: ""
+proc: ""
+qualified: ""
+rec: ""
+type: ""
+type family: ""
+type instance: ""
+where: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: HTML   |
+# ----------------------
+# << Keywords >>
+!DOCTYPE: "" #	Defines the document type
+a: "" #	Defines a hyperlink
+abbr: "" #	Defines an abbreviation or an acronym
+acronym: "" #	Not supported in HTML5. Use <abbr> instead. Defines an acronym
+address: "" #	Defines contact information for the author/owner of a document
+applet: "" #	Not supported in HTML5. Use <embed> or <object> instead. Defines an embedded applet
+area: "" #	Defines an area inside an image-map
+article: "" #	Defines an article
+aside: "" #	Defines content aside from the page content
+audio: "" #	Defines sound content
+b: "" #	Defines bold text
+base: "" #	Specifies the base URL/target for all relative URLs in a document
+basefont: "" #	Not supported in HTML5. Use CSS instead. Specifies a default color, size, and font for all text in a document
+bdi: "" #	Isolates a part of text that might be formatted in a different direction from other text outside it
+bdo: "" #	Overrides the current text direction
+big: "" #	Not supported in HTML5. Use CSS instead. Defines big text
+blockquote: "" #	Defines a section that is quoted from another source
+body: "" #	Defines the document's body
+br: "" #	Defines a single line break
+button: "" #	Defines a clickable button
+canvas: "" #	Used to draw graphics, on the fly, via scripting (usually JavaScript)
+caption: "" #	Defines a table caption
+center: "" #	Not supported in HTML5. Use CSS instead. Defines centered text
+cite: "" #	Defines the title of a work
+code: "" #	Defines a piece of computer code
+col: "" #	Specifies column properties for each column within a <colgroup> element
+colgroup: "" #	Specifies a group of one or more columns in a table for formatting
+data: "" #	Links the given content with a machine-readable translation
+datalist: "" #	Specifies a list of pre-defined options for input controls
+dd: "" #	Defines a description/value of a term in a description list
+del: "" #	Defines text that has been deleted from a document
+details: "" #	Defines additional details that the user can view or hide
+dfn: "" #	Represents the defining instance of a term
+dialog: "" #	Defines a dialog box or window
+dir: "" #	Not supported in HTML5. Use <ul> instead. Defines a directory list
+div: "" #	Defines a section in a document
+dl: "" #	Defines a description list
+dt: "" #	Defines a term/name in a description list
+em: "" #	Defines emphasized text
+embed: "" #	Defines a container for an external (non-HTML) application
+fieldset: "" #	Groups related elements in a form
+figcaption: "" #	Defines a caption for a <figure> element
+figure: "" #	Specifies self-contained content
+font: "" #	Not supported in HTML5. Use CSS instead. Defines font, color, and size for text
+footer: "" #	Defines a footer for a document or section
+form: "" #	Defines an HTML form for user input
+frame: "" #	Not supported in HTML5. Defines a window (a frame) in a frameset
+frameset: "" #	Not supported in HTML5. Defines a set of frames
+h1: "" # to <h6>	Defines HTML headings
+head: "" #	Defines information about the document
+header: "" #	Defines a header for a document or section
+hr: "" #	Defines a thematic change in the content
+html: "" #	Defines the root of an HTML document
+i: "" #	Defines a part of text in an alternate voice or mood
+iframe: "" #	Defines an inline frame
+img: "" #	Defines an image
+input: "" #	Defines an input control
+ins: "" #	Defines a text that has been inserted into a document
+kbd: "" #	Defines keyboard input
+label: "" #	Defines a label for an <input> element
+legend: "" #	Defines a caption for a <fieldset> element
+li: "" #	Defines a list item
+link: "" #	Defines the relationship between a document and an external resource (most used to link to style sheets)
+main: "" #	Specifies the main content of a document
+map: "" #	Defines a client-side image-map
+mark: "" #	Defines marked/highlighted text
+meta: "" #	Defines metadata about an HTML document
+meter: "" #	Defines a scalar measurement within a known range (a gauge)
+nav: "" #	Defines navigation links
+noframes: "" #	Not supported in HTML5. Defines an alternate content for users that do not support frames
+noscript: "" #	Defines an alternate content for users that do not support client-side scripts
+object: "" #	Defines an embedded object
+ol: "" #	Defines an ordered list
+optgroup: "" #	Defines a group of related options in a drop-down list
+option: "" #	Defines an option in a drop-down list
+output: "" #	Defines the result of a calculation
+p: "" #	Defines a paragraph
+param: "" #	Defines a parameter for an object
+picture: "" #	Defines a container for multiple image resources
+pre: "" #	Defines preformatted text
+progress: "" #	Represents the progress of a task
+q: "" #	Defines a short quotation
+rp: "" #	Defines what to show in browsers that do not support ruby annotations
+rt: "" #	Defines an explanation/pronunciation of characters (for East Asian typography)
+ruby: "" #	Defines a ruby annotation (for East Asian typography)
+s: "" #	Defines text that is no longer correct
+samp: "" #	Defines sample output from a computer program
+script: "" #	Defines a client-side script
+section: "" #	Defines a section in a document
+select: "" #	Defines a drop-down list
+small: "" #	Defines smaller text
+source: "" #	Defines multiple media resources for media elements (<video> and <audio>)
+span: "" #	Defines a section in a document
+strike: "" #	Not supported in HTML5. Use <del> or <s> instead. Defines strikethrough text
+strong: "" #	Defines important text
+style: "" #	Defines style information for a document
+sub: "" #	Defines subscripted text
+summary: "" #	Defines a visible heading for a <details> element
+sup: "" #	Defines superscripted text
+svg: "" #	Defines a container for SVG graphics
+table: "" #	Defines a table
+tbody: "" #	Groups the body content in a table
+td: "" #	Defines a cell in a table
+template: "" #	Defines a template
+textarea: "" #	Defines a multiline input control (text area)
+tfoot: "" #	Groups the footer content in a table
+th: "" #	Defines a header cell in a table
+thead: "" #	Groups the header content in a table
+time: "" #	Defines a date/time
+title: "" #	Defines a title for the document
+tr: "" #	Defines a row in a table
+track: "" #	Defines text tracks for media elements (<video> and <audio>)
+tt: "" #	Not supported in HTML5. Use CSS instead. Defines teletype text
+u: "" #	Defines text that should be stylistically different from normal text
+ul: "" #	Defines an unordered list
+var: "" #	Defines a variable
+video: "" #	Defines a video or movie
+wbr: "" #	Defines a possible line-break
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JAVA   |
+# ----------------------
+# << Keywords >>
+abstract: ""
+continue: ""
+for: ""
+new: ""
+switch: ""
+assert: ""
+default: ""
+goto: ""
+package: ""
+synchronized: ""
+boolean: ""
+do: ""
+if: ""
+private: ""
+this: ""
+break: ""
+double: ""
+implements: ""
+protected: ""
+throw: ""
+byte: ""
+else: ""
+import: ""
+public: ""
+throws: ""
+case: ""
+enum: ""
+instanceof: ""
+return: ""
+transient: ""
+catch: ""
+extends: ""
+int: ""
+short: ""
+try: ""
+char: ""
+final: ""
+interface: ""
+static: ""
+void: ""
+class: ""
+finally: ""
+long: ""
+strictfp: ""
+volatile: ""
+const: ""
+float: ""
+native: ""
+super: ""
+while: ""
+_: "" #_(underscore)
+
+# << Error Messages >>
+
+# ----------------------------
+# |   LANGUAGE: JAVASCRIPT   |
+# ----------------------------
+# << Keywords >>
+arguments: ""
+await: ""
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+eval: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+from: ""
+function: ""
+if: ""
+implements: ""
+import: ""
+in: ""
+instanceof: ""
+interface: ""
+let: ""
+new: ""
+null: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+return: ""
+static: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JULIA  |
+# ----------------------
+# << Keywords >>
+begin: ""
+while: ""
+if: ""
+for: ""
+try: ""
+return: ""
+break: ""
+continue: ""
+function: ""
+macro: ""
+quote: ""
+let: ""
+local: ""
+global: ""
+const: ""
+do: ""
+struct: ""
+abstract: "" #to be deprecated
+typealias: "" #to be deprecated
+bitstype: "" #to be deprecated
+type: "" #to be deprecated
+immutable: ""  #to be deprecated
+module: ""
+baremodule: ""
+using: ""
+import: ""
+export: ""
+importall: ""
+end: ""
+else: ""
+catch: ""
+finally: ""
+true: ""
+false: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSDOC  |
+# ----------------------
+# << Keywords >>
+@abstract: "" #(synonyms: @virtual) This member must be implemented (or overridden) by the inheritor.
+@access: "" # Specify the access level of this member (private, package-private, public, or protected).
+@alias: "" # Treat a member as if it had a different name.
+@async: "" # Indicate that a function is asynchronous.
+@augments: "" #(synonyms: @extends) Indicate that a symbol inherits from, and adds to, a parent symbol.
+@author: "" # Identify the author of an item.
+@borrows: "" # This object uses something from another object.
+@callback: "" # Document a callback function.
+@class: "" #(synonyms: @constructor) This function is intended to be called with the "new" keyword.
+@classdesc: "" # Use the following text to describe the entire class.
+@constant: "" #(synonyms: @const) Document an object as a constant.
+@constructs: "" # This function member will be the constructor for the previous class.
+@copyright: "" # Document some copyright information.
+@default: "" #(synonyms: @defaultvalue) Document the default value.
+@deprecated: "" # Document that this is no longer the preferred way.
+@description: "" #(synonyms: @desc) Describe a symbol.
+@enum: "" # Document a collection of related properties.
+@event: "" # Document an event.
+@example: "" # Provide an example of how to use a documented item.
+@exports: "" # Identify the member that is exported by a JavaScript module.
+@external: "" #(synonyms: @host) Identifies an external class, namespace, or module.
+@file: "" #(synonyms: @fileoverview, @overview) Describe a file.
+@fires: "" #(synonyms: @emits) Describe the events this method may fire.
+@function: "" #(synonyms: @func, @method) Describe a function or method.
+@generator: "" # Indicate that a function is a generator function.
+@global: "" # Document a global object.
+@hideconstructor: "" # Indicate that the constructor should not be displayed.
+@ignore: "" # Omit a symbol from the documentation.
+@implements: "" # This symbol implements an interface.
+@inheritdoc: "" # Indicate that a symbol should inherit its parent's documentation.
+@inner: "" # Document an inner object.
+@instance: "" # Document an instance member.
+@interface: "" # This symbol is an interface that others can implement.
+@kind: "" # What kind of symbol is this?
+@lends: "" # Document properties on an object literal as if they belonged to a symbol with a given name.
+@license: "" # Identify the license that applies to this code.
+@listens: "" #List the events that a symbol listens for.
+@member: "" #(synonyms: @var)Document a member.
+@memberof: "" #This symbol belongs to a parent symbol.
+@mixes: "" #This object mixes in all the members from another object.
+@mixin: "" #Document a mixin object.
+@module: "" #Document a JavaScript module.
+@name: "" #Document the name of an object.
+@namespace: "" #Document a namespace object.
+@override: "" #Indicate that a symbol overrides its parent.
+@package: "" # This symbol is meant to be package-private.
+@param: "" #(synonyms: @arg, @argument)Document the parameter to a function.
+@private: "" #This symbol is meant to be private.
+@property: "" #(synonyms: @prop) Document a property of an object.
+@protected: "" #This symbol is meant to be protected.
+@public: "" #This symbol is meant to be public.
+@readonly: "" #This symbol is meant to be read-only.
+@requires: "" #This file requires a JavaScript module.
+@returns: "" #(synonyms: @return)Document the return value of a function.
+@see: "" #Refer to some other documentation for more information.
+@since: "" #When was this feature added?
+@static: "" #Document a static member.
+@summary: "" #A shorter version of the full description.
+@this: "" #What does the 'this' keyword refer to here?
+@throws: "" #(synonyms: @exception) Describe what errors could be thrown.
+@todo: "" #Document tasks to be completed.
+@tutorial: "" #Insert a link to an included tutorial file.
+@type: "" #Document the type of an object.
+@typedef: "" # Document a custom type.
+@variation: "" # Distinguish different objects with the same name.
+@version: "" # Documents the version number of an item.
+@yields: "" #(synonyms: @yield) Document the value yielded by a generator function.
+{@link}: "" # (synonyms: {@linkcode}, {@linkplain}) Link to another item in the documentation.
+{@tutorial}: "" # Link to a tutorial.
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: JSON   |
+# ----------------------
+# << Keywords >>
+# Not really sure how to do this for JSON
+$schema: ""
+$ref: ""
+$id: ""
+$comment: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: NODE   |
+# ----------------------
+# << Keywords >>
+__dirname: ""
+__filename: ""
+exports: ""
+module: ""
+require: "" #require()
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: OCAML  |
+# ----------------------
+# << Keywords >>
+and: "" #
+as: "" #
+assert: "" #
+asr: "" #
+begin: "" #
+class: "" #
+constraint: "" #
+do: "" #
+done: "" #
+downto: "" #
+else: "" #
+end: "" #
+exception: "" #
+external: "" #
+false: "" #
+for: "" #
+fun: "" #
+function: "" #
+functor: "" #
+if: "" #
+in: "" #
+include: "" #
+inherit: "" #
+initializer: "" #
+land: "" #
+lazy: "" #
+let: "" #
+lor: "" #
+lsl: "" #
+lsr: "" #
+lxor: "" #
+match: "" #
+method: "" #
+mod: "" #
+module: "" #
+mutable: "" #
+new: "" #
+nonrec: "" #
+object: "" #
+of: "" #
+open: "" #
+or: "" #
+private: "" #
+rec: "" #
+sig: "" #
+struct: "" #
+then: "" #
+to: "" #
+true: "" #
+try: "" #
+type: "" #
+val: "" #
+virtual: "" #
+when: "" #
+while: "" #
+with: "" #
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: PHP    |
+# ----------------------
+# << Keywords >>
+__halt_compiler: ""
+abstract: ""
+and: ""
+array: ""
+as: ""
+break: ""
+callable: ""
+case: ""
+catch: ""
+class: ""
+clone: ""
+const: ""
+continue: ""
+declare: ""
+default: ""
+die: ""
+do: ""
+echo: ""
+else: ""
+elseif: ""
+empty: ""
+enddeclare: ""
+endfor: ""
+endforeach: ""
+endif: ""
+endswitch: ""
+endwhile: ""
+eval: ""
+exit: ""
+extends: ""
+final: ""
+for: ""
+foreach: ""
+function: ""
+global: ""
+goto: ""
+if: ""
+implements: ""
+include: ""
+include_once: ""
+instanceof: ""
+insteadof: ""
+interface: ""
+isset: ""
+list: ""
+namespace: ""
+new: ""
+or: ""
+print: ""
+private: ""
+protected: ""
+public: ""
+require: ""
+require_once: ""
+return: ""
+static: ""
+switch: ""
+throw: ""
+trait: ""
+try: ""
+unset: ""
+use: ""
+var: ""
+while: ""
+xor: ""
+__CLASS__: ""
+__DIR__: ""
+__FILE__: ""
+__FUNCTION__: ""
+__LINE__: ""
+__METHOD__: ""
+__NAMESPACE__: ""
+__TRAIT__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |  LANGUAGE: PYTHON  |
+# ----------------------
+# << Keywords >>
+  False: ""
+  None: ""
+  True: ""
+  and: ""
+  as: ""
+  assert: ""
+  async: ""
+  await: ""
+  break: ""
+  class: ""
+  continue: ""
+  def: ""
+  del: ""
+  elif: ""
+  else: ""
+  except: ""
+  finally: ""
+  for: ""
+  from: ""
+  global:  ""
+  if: ""
+  import: ""
+  in: ""
+  is: ""
+  lambda: ""
+  nonlocal: ""
+  not: ""
+  or: ""
+  pass: ""
+  raise: ""
+  return: ""
+  try: ""
+  while: ""
+  with: ""
+  yield: ""
+
+# << Built-In Functions >>
+
+  abs: ""
+  all: ""
+  any: ""
+  ascii: ""
+  bin: ""
+  bool: ""
+  breakpoint: ""
+  bytearray: ""
+  bytes: ""
+  callable: ""
+  chr: ""
+  classmethod: ""
+  compile: ""
+  complex: ""
+  delattr: ""
+  dict: ""
+  dir: ""
+  divmod: ""
+  enumerate: ""
+  eval: ""
+  exec: ""
+  filter: ""
+  float: ""
+  format: ""
+  frozenset: ""
+  getattr: ""
+  globals: ""
+  hasattr: ""
+  hash: ""
+  help: ""
+  hex: ""
+  id: ""
+  input: ""
+  int: ""
+  isinstance: ""
+  issubclass: ""
+  iter: ""
+  len: ""
+  list: ""
+  locals: ""
+  map: ""
+  max: ""
+  memoryview: ""
+  min: ""
+  next: ""
+  object: ""
+  oct: ""
+  open: ""
+  ord: ""
+  pow: ""
+  print: ""
+  property: ""
+  range: ""
+  repr: ""
+  reversed: ""
+  round: ""
+  set: ""
+  setattr: ""
+  slice: ""
+  sorted: ""
+  staticmethod: ""
+  str: ""
+  sum: ""
+  super: ""
+  tuple: ""
+  type: ""
+  vars: ""
+  zip: ""
+  __import__: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RAZOR   |
+# ----------------------
+# << Keywords >>
+page: "" # (Requires ASP.NET Core 2.0 and later)
+namespace: "" #
+functions: "" #
+inherits: "" #
+model: "" #
+section: "" #
+helper: "" # (Not currently supported by ASP.NET Core)
+@case: "" #
+@do: "" #
+@default: "" #
+@for: "" #
+@foreach: "" #
+@if: "" #
+@else: "" #
+@lock: "" #
+@switch: "" #
+@try: "" #
+@catch: "" #
+@finally: "" #
+@using: "" #
+@while: "" #
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: REGEX  |
+# ----------------------
+# << Keywords >>
+# Not sure how to template that out // taking all ideas
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: RUBY   |
+# ----------------------
+# << Keywords >>
+alias: ""
+and: ""
+begin: ""
+break: ""
+case: ""
+class: ""
+def: ""
+defined?: ""
+do: ""
+else: ""
+elsif: ""
+end: ""
+ensure: ""
+false: ""
+for: ""
+if: ""
+in: ""
+module: ""
+next: ""
+nil: ""
+not: ""
+or: ""
+redo: ""
+rescue: ""
+retry: ""
+return: ""
+self: ""
+super: ""
+then: ""
+true: ""
+undef: ""
+unless: ""
+until: ""
+when: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE:  RUST  |
+# ----------------------
+# << Keywords >>
+
+_: ""
+abstract: ""
+alignof: ""
+as: ""
+become: ""
+box: ""
+break: ""
+const: ""
+continue: ""
+crate: ""
+do: ""
+else: ""
+enum: ""
+extern: ""
+false: ""
+final: ""
+fn: ""
+for: ""
+if: ""
+impl: ""
+in: ""
+let: ""
+loop: ""
+macro: ""
+match: ""
+mod: ""
+move: ""
+mut: ""
+offsetof: ""
+override: ""
+priv: ""
+proc: ""
+pub: ""
+pure: ""
+ref: ""
+return: ""
+Self: ""
+self: ""
+sizeof: ""
+static: ""
+struct: ""
+super: ""
+trait: ""
+true: ""
+type: ""
+typeof: ""
+unsafe: ""
+unsized: ""
+use: ""
+virtual: ""
+where: ""
+while: ""
+yield: ""
+
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SCALA  |
+# ----------------------
+# << Keywords >>
+abstract: ""
+case: ""
+catch: ""
+class: ""
+def: ""
+do: ""
+else: ""
+extends: ""
+false: ""
+final: ""
+finally: ""
+for: ""
+forSome: ""
+if: ""
+implicit: ""
+import: ""
+lazy: ""
+macro: ""
+match: ""
+new: ""
+null: ""
+object: ""
+override: ""
+package: ""
+private: ""
+protected: ""
+return: ""
+sealed: ""
+super: ""
+this: ""
+throw: ""
+trait: ""
+try: ""
+true: ""
+type: ""
+val: ""
+var: ""
+while: ""
+with: ""
+yield: ""
+# << Error Messages >>
+
+# ----------------------
+# |   LANGUAGE: SWIFT   |
+# ----------------------
+# << Keywords >>
+associatedtype: ""
+class: ""
+deinit: ""
+enum: ""
+extension: ""
+func: ""
+import: ""
+init: ""
+inout: ""
+internal: ""
+let: ""
+operator: ""
+private: ""
+protocol: ""
+public: ""
+static: ""
+struct: ""
+subscript: ""
+typealias: ""
+var: ""
+break: ""
+case: ""
+continue: ""
+default: ""
+defer: ""
+do: ""
+else: ""
+fallthrough: ""
+for: ""
+guard: ""
+if: ""
+in: ""
+repeat: ""
+return: ""
+switch: ""
+where: ""
+while: ""
+as: ""
+catch: ""
+dynamicType: ""
+false: ""
+is: ""
+nil: ""
+rethrows: ""
+super: ""
+self: ""
+Self: ""
+throw: ""
+throws: ""
+true: ""
+try: ""
+#column: ""
+#file: ""
+#function: ""
+#line: ""
+#available: ""
+#column: ""
+#else: ""
+#elseif: ""
+#endif: ""
+#file: ""
+#function: ""
+#if: ""
+#line: ""
+#selector: ""
+associativity: ""
+convenience: ""
+dynamic: ""
+didSet: ""
+final: ""
+get: ""
+infix: ""
+indirect: ""
+lazy: ""
+left: ""
+mutating: ""
+none: ""
+nonmutating: ""
+optional: ""
+override: ""
+postfix: ""
+precedence: ""
+prefix: ""
+Protocol: ""
+required: ""
+right: ""
+set: ""
+Type: ""
+unowned: ""
+weak: ""
+willSet: ""
+
+# << Error Messages >>
+
+# ---------------------------
+# |   LANGUAGE: TYPESCRIPT  |
+# ---------------------------
+# << Keywords >>
+break: ""
+case: ""
+catch: ""
+class: ""
+const: ""
+continue: ""
+debugger: ""
+default: ""
+delete: ""
+do: ""
+else: ""
+enum: ""
+export: ""
+extends: ""
+false: ""
+finally: ""
+for: ""
+function: ""
+if: ""
+import: ""
+in: ""
+instanceof: ""
+new: ""
+null: ""
+return: ""
+super: ""
+switch: ""
+this: ""
+throw: ""
+true: ""
+try: ""
+typeof: ""
+var: ""
+void: ""
+while: ""
+with: ""
+as: ""
+implements: ""
+interface: ""
+let: ""
+package: ""
+private: ""
+protected: ""
+public: ""
+static: ""
+yield: ""
+any: ""
+boolean: ""
+constructor: ""
+declare: ""
+get: ""
+module: ""
+require: ""
+number: ""
+set: ""
+string: ""
+symbol: ""
+type: ""
+from: ""
+of: ""
+
+# << Error Messages >>
+
+# ------------------------
+# |   LANGUAGE: VERILOG  |
+# ------------------------
+# << Keywords >>
+
+always: ""
+and: ""
+assign: ""
+begin: ""
+buf: ""
+bufif0: ""
+bufif1: ""
+case: ""
+casex: ""
+casez: ""
+cmos: ""
+deassign: ""
+default: ""
+defparam: ""
+disable: ""
+edge: ""
+else: ""
+end: ""
+endcase: ""
+endfunction: ""
+endmodule: ""
+endprimitive: ""
+endspecify: ""
+endtable: ""
+endtask: ""
+event: ""
+for: ""
+force: ""
+forever: ""
+fork: ""
+function: ""
+highz0: ""
+highz1: ""
+if: ""
+initial: ""
+inout: ""
+input: ""
+integer: ""
+join: ""
+large: ""
+macromodule: ""
+medium: ""
+module: ""
+nand: ""
+negedge: ""
+nmos: ""
+nor: ""
+not: ""
+notif0: ""
+notif1: ""
+or: ""
+output: ""
+pmos: ""
+posedge: ""
+primitive: ""
+pull0: ""
+pull1: ""
+pulldown: ""
+pullup: ""
+rcmos: ""
+reg: ""
+release: ""
+repeat: ""
+rnmos: ""
+rpmos: ""
+rtran: ""
+rtranif0: ""
+rtranif1: ""
+scalared: ""
+small: ""
+specify: ""
+specparam: ""
+strong0: ""
+strong1: ""
+supply0: ""
+supply1: ""
+table: ""
+task: ""
+time: ""
+tran: ""
+tranif0: ""
+tranif1: ""
+tri: ""
+tri0: ""
+tri1: ""
+triand: ""
+trior: ""
+vectored: ""
+wait: ""
+wand: ""
+weak0: ""
+weak1: ""
+while: ""
+wire: ""
+wor: ""
+xnor: ""
+xor: ""
+
+# << Error Messages >>


### PR DESCRIPTION
## Why

After the merge-ours sweep (PR #322) and branch cleanup, you pointed out that main only has 5 files in `locale/` while the repo's README talks about 30+ language translations. That's accurate — the merge-ours sweep preserved every contributor's commit authorship in main's **ancestry** but by design didn't bring their **file content** onto main's tree. The language YAMLs lived only on the `{lang}-translation` feature branches; after those branches were deleted, the content was still in git (via the merge-ours commits' second parents) but not browsable.

This PR fixes that — restores every language YAML to main so they're visible at github.com/legesher/legesher-translations/tree/main/locale/.

## What changes

**29 language YAML files added to `locale/`**, each pulled from the appropriate merge-ours commit's second parent (which is the branch tip the sweep preserved):

| Lang | File | Source branch (via merge-ours 2nd parent) | Commits authors |
|---|---|---|---|
| Arabic | `locale/ar.yml` | arabic-translation | 5 |
| Azerbaijani | `locale/az.yml` | azerbaijani-translation | 1 |
| Bengali | `locale/bn.yml` | bengali-translation | 1 |
| Welsh | `locale/cy.yml` | welsh-translation | 2 |
| Danish | `locale/da.yml` | danish-translation | 1 |
| German | `locale/de.yaml` | german-translation | 2 |
| Greek | `locale/el.yml` | greek-translation | 1 |
| Spanish | `locale/es.yml` | spanish-translation | 9 |
| Finnish | `locale/fi.yml` | finnish-translation | 3 |
| French | `locale/fr.yml` | french-translation | 4 |
| Gaelic | `locale/ga.yml` | gaelic-translation | 1 |
| Gujarati | `locale/gu.yml` | gujarati-translation | 9 |
| Hebrew | `locale/he.yml` | hebrew-translation | 4 |
| Hindi | `locale/hi.yml` | hindi-translation | 11 |
| Indonesian | `locale/id.yml` | indonesian-translation | 4 |
| Italian | `locale/it.yml` | italian-translation | 5 |
| Malayalam | `locale/ml.yml` | malayalam-translation | 2 |
| Nepali | `locale/ne.yml` | nepali-translation | 1 |
| Dutch | `locale/nl.yml` | dutch-translation | 1 |
| Polish | `locale/pl.yml` | polish-translation | 1 |
| Portuguese | `locale/pt.yml` | portuguese-translation | 8 |
| Romanian | `locale/ro.yml` | romanian-translation | 1 |
| Russian | `locale/ru.yml` | russian-translation | 2 |
| Telugu | `locale/te.yml` | telugu-translation | 7 |
| Tagalog | `locale/tl.yml` | tagalog-translation | 2 |
| Turkish | `locale/tr.yml` | turkish-translation | 1 |
| Ukrainian | `locale/uk.yml` | ukrainian-translation | 4 |
| Xhosa | `locale/xh.yml` | xhosa-translation | 1 |
| Chinese | `locale/zh.yml` | chinese-translation | 1 |

(Swahili `sw.yml` and Urdu `ur.yml` are already on main from PR #324.)

## Co-authorship

**73 contributors are listed as Co-Authored-By** on this single commit — every person who ever committed to any of these 29 files. Applying your earlier feedback: when a commit integrates someone's work onto main, they deserve to be a co-author of that specific commit, not just credited in a follow-up.

Madison is the author (as the person doing the cherry-pick), not a co-author (avoiding redundancy).

## No data mutation

Every byte in these 29 files is identical to what the original contributors committed — we're not transforming or reformatting their work, just bringing the exact blobs from the preserved ancestry onto main's tree. The blobs' SHAs match what was on the deleted branches.

## After this merges

- main's `locale/` directory will have **34 files** (3 original templates + sw + ur + 29 restored = 34)
- `README.md`'s contributor table already credits everyone; no regen needed
- `v1.0.0-legacy` tag still points at current main (a52be7e); after merge I can move the tag forward to include these files if you want

Signed-off-by: Madison (Pfaff) Edgar <7844510+madiedgar@users.noreply.github.com>