### PR TITLE
docs(archive): update contributor count badge 82 -> 149 [CORE-673]

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
     <!-- <a href="https://github.com/legesher/legesher-translations/graphs/contributors" alt="Contributors">
         <img src="https://img.shields.io/github/contributors/legesher/legesher-translations?style=flat-square&color=f58977&labelColor=black" /></a> -->
     <a href="#the-community" alt="All Contributors">
-        <img src="https://img.shields.io/badge/all_contributors-82-black?style=flat-square&color=f58977&labelColor=black" /></a>
+        <img src="https://img.shields.io/badge/all_contributors-149-black?style=flat-square&color=f58977&labelColor=black" /></a>
     <a href="https://github.com/sponsors/madiedgar" alt="Sponsors on Github">
         <img src="https://img.shields.io/badge/sponsor-@madiedgar-black?style=flat-square&color=f58977&labelColor=black" /></a>
 


### PR DESCRIPTION
## Why

The shields.io contributor-count badge at the top of the README was hardcoded at `82` — the count from before our archival attribution pass. After PR #326 brought the contributor count to 149, the badge stayed stale because `all-contributors-cli generate` only rebuilds the emoji-table between `<!-- ALL-CONTRIBUTORS-LIST -->` markers; it doesn't touch standalone shields.io URLs elsewhere in the README.

Good catch by Madison noticing.

## Change

```diff
-<img src="https://img.shields.io/badge/all_contributors-82-black?…" />
+<img src="https://img.shields.io/badge/all_contributors-149-black?…" />
```

One line. Badge now matches the table below it (149 contributors with emoji badges).

Signed-off-by: Madison (Pfaff) Edgar <7844510+madiedgar@users.noreply.github.com>